### PR TITLE
Change "timestamp" to "release"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ You'll need the test-kitchen & kitchen-habitat gems installed in your system, al
 * `hab_sup_version`
   * Version number of `hab-sup` to run
   * Defaults to `nil`, or, if `hab_sup_artifact_name` is supplied, the `hab_sup_version` will be parsed from the filename of the hart file.
-* `hab_sup_timestamp`
-  * Timestamp of the `hab-sup` package to run
-  * Defaults to `nil`, or, if `hab_sup_artifact_name` is supplied, the `hab_sup_timestamp` will be parsed from the filename of the hart file.
+* `hab_sup_release`
+  * Release of the `hab-sup` package to run
+  * Defaults to `nil`, or, if `hab_sup_artifact_name` is supplied, the `hab_sup_release` will be parsed from the filename of the hart file.
 * `hab_sup_artifact_name`
   * Artifact package name for a custom supervisor to run
   * Used to upload and test a local supervisor.
@@ -66,9 +66,9 @@ You'll need the test-kitchen & kitchen-habitat gems installed in your system, al
 * `package_version`
   * Package version of the package to be run.
   * Defaults to `nil` or if `artifact_name` is supplied, the `package_version` will be parsed from the filename of the hart file.
-* `package_timestamp`
-  * Package timestamp of the package to be run.
-  * Defaults to `nil` or if `artifact_name` is supplied, the `package_timestamp` will be parsed from the filename of the hart file.
+* `package_releae`
+  * Package release of the package to be run.
+  * Defaults to `nil` or if `artifact_name` is supplied, the `package_release` will be parsed from the filename of the hart file.
 * `service_topology`
   * The topology for the service to run in.  Valid values are `nil`, `standalone`, `leader`
   * Defaults to `nil` which is `standalone`

--- a/lib/kitchen/provisioner/habitat.rb
+++ b/lib/kitchen/provisioner/habitat.rb
@@ -20,7 +20,7 @@ module Kitchen
       default_config :hab_sup_origin, "core"
       default_config :hab_sup_name, "hab-sup"
       default_config :hab_sup_version, nil
-      default_config :hab_sup_timestamp, nil
+      default_config :hab_sup_release, nil
       default_config :hab_sup_artifact_name, nil
 
       # hab-sup manager options
@@ -37,7 +37,7 @@ module Kitchen
         provisioner.instance.suite.name
       end
       default_config :package_version, nil
-      default_config :package_timestamp, nil
+      default_config :package_release, nil
       default_config :service_topology, nil
       default_config :service_update_strategy, nil
 
@@ -56,7 +56,7 @@ module Kitchen
           config[:hab_sup_origin] = ident["origin"]
           config[:hab_sup_name] = ident["name"]
           config[:hab_sup_version] = ident["version"]
-          config[:hab_sup_timestamp] = ident["timestamp"]
+          config[:hab_sup_release] = ident["release"]
         end
 
         unless config[:artifact_name].nil?
@@ -64,7 +64,7 @@ module Kitchen
           config[:package_origin] = ident["origin"]
           config[:package_name] = ident["name"]
           config[:package_version] = ident["version"]
-          config[:package_timestamp] = ident["timestamp"]
+          config[:package_release] = ident["release"]
         end
         super(instance)
       end
@@ -225,14 +225,14 @@ module Kitchen
       end
 
       def artifact_name_to_package_ident_regex
-        /(?<origin>\w+)-(?<name>.*)-(?<version>(\d+)?(\.\d+)?(\.\d+)?(\.\d+)?)-(?<timestamp>\d+)-(?<target>.*)\.hart$/
+        /(?<origin>\w+)-(?<name>.*)-(?<version>(\d+)?(\.\d+)?(\.\d+)?(\.\d+)?)-(?<release>\d+)-(?<target>.*)\.hart$/
       end
 
       def hab_sup_ident
         ident = "#{config[:hab_sup_origin]}/" \
                 "#{config[:hab_sup_name]}/" \
                 "#{config[:hab_sup_version]}/" \
-                "#{config[:hab_sup_timestamp]}".chomp("/").chomp("/")
+                "#{config[:hab_sup_release]}".chomp("/").chomp("/")
         @sup_ident ||= ident
       end
 
@@ -240,7 +240,7 @@ module Kitchen
         ident = "#{config[:package_origin]}/" \
                 "#{config[:package_name]}/" \
                 "#{config[:package_version]}/" \
-                "#{config[:package_timestamp]}".chomp("/").chomp("/")
+                "#{config[:package_release]}".chomp("/").chomp("/")
         @pkg_ident ||= ident
       end
 


### PR DESCRIPTION
"release" is used consistently in the Habitat code base and
documentation. While it is technically a timestamp, this is not what it
is called.

Signed-off-by: Nathan L Smith <smith@chef.io>