### PR TITLE
Use package ident regex to detect artifact name

### DIFF
--- a/lib/kitchen/provisioner/habitat.rb
+++ b/lib/kitchen/provisioner/habitat.rb
@@ -244,11 +244,11 @@ module Kitchen
         else
           return
         end
-        parsed_name = artifact_name.split("-")
-        config[:package_origin] = parsed_name[0]
-        config[:package_name] = parsed_name[1]
-        config[:package_version] = parsed_name[2]
-        config[:package_release] = parsed_name[3]
+        ident = artifact_name_to_package_ident_regex.match(artifact_name)
+        config[:package_origin] = ident["origin"]
+        config[:package_name] = ident["name"]
+        config[:package_version] = ident["version"]
+        config[:package_release] = ident["release"]
 
         artifact_path = File.join(File.join(config[:root_path], "results"), artifact_name)
         "sudo -E hab pkg install #{artifact_path}"

--- a/spec/kitchen/provisioner/habitat_spec.rb
+++ b/spec/kitchen/provisioner/habitat_spec.rb
@@ -23,15 +23,16 @@ def wrap_command(code, left_pad_length = 10)
 end
 
 describe Kitchen::Provisioner::Habitat do
-  let(:logged_output) { StringIO.new }
-  let(:logger)        { Logger.new(logged_output) }
-  let(:config)        { { kitchen_root: "/kroot" } }
-  let(:platform)      { Kitchen::Platform.new(name: "fooos-99") }
-  let(:suite)         { Kitchen::Suite.new(name: "suitey") }
-  let(:verifier)      { Kitchen::Verifier::Dummy.new }
-  let(:driver)        { Kitchen::Driver::Dummy.new }
-  let(:transport)     { Kitchen::Transport::Dummy.new }
-  let(:state_file)    { double("state_file") }
+  let(:logged_output)   { StringIO.new }
+  let(:logger)          { Logger.new(logged_output) }
+  let(:lifecycle_hooks) { Kitchen::LifecycleHooks.new({}) }
+  let(:config)          { { kitchen_root: "/kroot" } }
+  let(:platform)        { Kitchen::Platform.new(name: "fooos-99") }
+  let(:suite)           { Kitchen::Suite.new(name: "suitey") }
+  let(:verifier)        { Kitchen::Verifier::Dummy.new }
+  let(:driver)          { Kitchen::Driver::Dummy.new }
+  let(:transport)       { Kitchen::Transport::Dummy.new }
+  let(:state_file)      { double("state_file") }
 
   let(:provisioner_object) { Kitchen::Provisioner::Habitat.new(config) }
 
@@ -46,6 +47,7 @@ describe Kitchen::Provisioner::Habitat do
       verifier:  verifier,
       driver: driver,
       logger: logger,
+      lifecycle_hooks: lifecycle_hooks,
       suite: suite,
       platform: platform,
       provisioner: provisioner_object,


### PR DESCRIPTION
If artifact name contains dashes then package ident will be invalid.

Second patch: Add lifecycle hooks to the unit tests.
LifecycleHooks were introduced and without this patch tests are failed to run.
