### PR TITLE
Loosen the Test Kitchen dep + resolve Chefstyle warnings

### DIFF
--- a/kitchen-habitat.gemspec
+++ b/kitchen-habitat.gemspec
@@ -8,23 +8,21 @@ Gem::Specification.new do |s|
   s.email             = ["smurawski@chef.io"]
   s.homepage          = "https://github.com/test-kitchen/kitchen-habitat"
   s.summary           = "Habitat provisioner for test-kitchen"
-  candidates          = Dir.glob("lib/**/*") + ["README.md", "kitchen-habitat.gemspec"]
+  candidates          = Dir.glob("lib/**/*") + ["README.md"]
   s.files             = candidates.sort
-  s.platform          = Gem::Platform::RUBY
   s.require_paths     = ["lib"]
-  s.rubyforge_project = "[none]"
-  s.license           = "Apache 2"
-  s.description       = <<-EOF
-== DESCRIPTION:
+  s.license           = "Apache-2.0"
+  s.description       = <<~EOF
+    == DESCRIPTION:
 
-Habitat Provisioner for Test Kitchen
+    Habitat Provisioner for Test Kitchen
 
-== FEATURES:
+    == FEATURES:
 
-TBD
+    TBD
 
-EOF
-  s.add_dependency "test-kitchen", "~> 1.4"
+  EOF
+  s.add_dependency "test-kitchen", ">= 1.4", "< 3"
 
   s.add_development_dependency "countloc", "~> 0.4"
   s.add_development_dependency "rake"

--- a/lib/kitchen/provisioner/habitat.rb
+++ b/lib/kitchen/provisioner/habitat.rb
@@ -118,7 +118,7 @@ module Kitchen
           #{install_service_package}
           #{remove_previous_user_toml}
           #{copy_user_toml_to_service_directory}
-          EOH
+        EOH
       end
 
       def run_command
@@ -160,20 +160,20 @@ module Kitchen
       end
 
       def sup_run_script
-        <<-SCRIPT
-cat > /tmp/sup-run.sh <<"END"
-#!/bin/bash
+        <<~SCRIPT
+          cat > /tmp/sup-run.sh <<"END"
+          #!/bin/bash
 
-while true
-do
-  COUNT=$(ps aux | grep hab | wc -l)
-  if [[ ${COUNT} -lt 2 ]]
-  then
-    sudo -E hab sup run #{supervisor_options} > ~/nohup.out & echo $! > /tmp/run.pid
-  fi
-done
-END
-SCRIPT
+          while true
+          do
+            COUNT=$(ps aux | grep hab | wc -l)
+            if [[ ${COUNT} -lt 2 ]]
+            then
+              sudo -E hab sup run #{supervisor_options} > ~/nohup.out & echo $! > /tmp/run.pid
+            fi
+          done
+          END
+        SCRIPT
       end
 
       def run_package_in_background


### PR DESCRIPTION
This plugin won't be impacted by Test Kitchen 2.0
Resovle all the new chefstyle warnings for the updated release
Fixup the gemspec a bit and don't ship the gemspec in the gem artifact
as it's not needed

Signed-off-by: Tim Smith <tsmith@chef.io>