### PR TITLE
Require Ruby 2.5+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ Gemfile.lock
 *.gem
 .bundle
 .config
-.rubocop.yml
 coverage
 InstalledFiles
 lib/bundler/man

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+---
+AllCops:
+  TargetRubyVersion: 2.5
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+Please refer to the Chef Community Code of Conduct at https://www.chef.io/code-of-conduct/

--- a/kitchen-habitat.gemspec
+++ b/kitchen-habitat.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
     TBD
 
   EOF
-  
+
   s.required_ruby_version = ">= 2.5"
-  
+
   s.add_dependency "test-kitchen", ">= 1.4", "< 3"
 end

--- a/kitchen-habitat.gemspec
+++ b/kitchen-habitat.gemspec
@@ -22,5 +22,8 @@ Gem::Specification.new do |s|
     TBD
 
   EOF
+  
+  s.required_ruby_version = ">= 2.5"
+  
   s.add_dependency "test-kitchen", ">= 1.4", "< 3"
 end


### PR DESCRIPTION
Drop support for EOL ruby

Signed-off-by: Tim Smith <tsmith@chef.io>