### PR TITLE
Docs: rewrite README for new users and split contributor docs

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+---
+default: true
+MD004: false
+MD012: false
+MD013: false
+MD024: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing to kitchen-habitat
+
+Thanks for your interest in improving kitchen-habitat. Bug reports, feature requests, and pull requests are all welcome.
+
+## Reporting issues
+
+Report bugs and request features on the [issue tracker](https://github.com/test-kitchen/kitchen-habitat/issues). For bugs, please include:
+
+- the version of kitchen-habitat and Test Kitchen you are using
+- the Habitat version, and whether the supervisor came from a depot or a local `.hart`
+- your `kitchen.yml`
+- the output of the failing command, ideally with `-l debug`
+
+Converges that fail while waiting for a service to come up are often a
+`service_load_timeout` that is too short rather than a bug — worth ruling out
+first.
+
+## Development setup
+
+Clone the repository and install the dependencies:
+
+```sh
+git clone https://github.com/test-kitchen/kitchen-habitat.git
+cd kitchen-habitat
+bundle install
+```
+
+## Running the tests
+
+Run the unit tests and the style check together:
+
+```sh
+bundle exec rake
+```
+
+Run them individually:
+
+```sh
+bundle exec rake test    # RSpec unit tests
+bundle exec rake style   # Cookstyle / RuboCop
+```
+
+To run a single spec file:
+
+```sh
+bundle exec rspec spec/kitchen/provisioner/habitat_spec.rb
+```
+
+Many style offenses can be corrected automatically:
+
+```sh
+bundle exec cookstyle -a
+```
+
+The unit tests assert on the shell and PowerShell the provisioner generates.
+They do not install Habitat or start a supervisor, so they run anywhere.
+
+## Manual testing
+
+Because the unit tests only check the generated commands, anything touching
+installation, service load, or supervisor options should also be run end to end
+against a real instance.
+
+Worth exercising separately, since they take different paths through the
+provisioner:
+
+- **a depot package**, using `package_origin` and `package_name`
+- **a local artifact**, using `artifact_name` or `install_latest_artifact` with a
+  `results_directory` produced by a Habitat studio build
+- **Linux and Windows**, which have entirely separate command generation
+- **multi-service suites**, using `hab_sup_peer` and `hab_sup_bind`
+
+## Submitting changes
+
+1. Fork the repository.
+2. Create a feature branch off `main`.
+3. Make your change, adding or updating tests to cover it.
+4. Make sure `bundle exec rake` passes.
+5. Push the branch to your fork and open a pull request.
+
+Please keep pull requests focused on a single change — it makes review much
+faster. Update the documentation in `README.md` when you add or change a
+configuration option.
+
+## Release process
+
+Releases are handled by the maintainers.
+
+1. Update `lib/kitchen-habitat/version.rb` with the new version.
+2. Update `CHANGELOG.md`.
+3. Merge to `main`; the publish workflow builds the gem and pushes it to
+   RubyGems.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,106 @@
-[![Gem Version](https://badge.fury.io/rb/kitchen-habitat.svg)](https://badge.fury.io/rb/kitchen-habitat)
-[![CI](https://github.com/test-kitchen/kitchen-habitat/workflows/CI/badge.svg?branch=master)](https://github.com/test-kitchen/kitchen-habitat/actions?query=workflow%3ACI+branch%3Amaster)
-
 # kitchen-habitat
 
-A Test Kitchen Provisioner for [Habitat](https://habitat.sh)
+[![Gem Version](https://badge.fury.io/rb/kitchen-habitat.svg)](https://badge.fury.io/rb/kitchen-habitat)
+[![Unit](https://github.com/test-kitchen/kitchen-habitat/actions/workflows/unit.yml/badge.svg)](https://github.com/test-kitchen/kitchen-habitat/actions/workflows/unit.yml)
+[![linters](https://github.com/test-kitchen/kitchen-habitat/actions/workflows/linters.yml/badge.svg)](https://github.com/test-kitchen/kitchen-habitat/actions/workflows/linters.yml)
+
+A [Test Kitchen](https://kitchen.ci/) provisioner for [Habitat](https://habitat.sh). It installs the Habitat
+supervisor on your test instance, loads the service you are working on, and waits for it to come up, so you can test
+Habitat packages the same way you would test a cookbook.
+
+> This documentation uses [Cinc Workstation](https://cinc.sh/) and the `cinc` commands throughout. Everything here
+> works identically with Chef Workstation — see [Using with Chef](#using-with-chef).
 
 ## Requirements
 
-## Installation & Setup
+- Ruby 3.1 or later (already satisfied if you use Cinc Workstation)
+- A Test Kitchen driver to supply instances, such as
+  [kitchen-vagrant](https://github.com/test-kitchen/kitchen-vagrant),
+  [kitchen-docker](https://github.com/test-kitchen/kitchen-docker), or
+  [kitchen-ec2](https://github.com/test-kitchen/kitchen-ec2)
+- A Habitat package to test, either from a depot or built locally in a Habitat studio
 
-You'll need the test-kitchen & kitchen-habitat gems installed in your system, along with kitchen-vagrant or some other suitable driver for test-kitchen.
+The provisioner installs the `hab` binary on the instance itself, so you do not need Habitat installed locally unless
+you are building artifacts to upload.
+
+## Installation
+
+This provisioner ships as part of [Cinc Workstation](https://cinc.sh/start/workstation/). If you have Cinc
+Workstation installed, there is nothing else to install.
+
+To install it into a standalone Ruby:
+
+```sh
+gem install kitchen-habitat
+```
+
+Or with Bundler, add it to your `Gemfile` alongside Test Kitchen and a driver:
+
+```ruby
+gem "test-kitchen"
+gem "kitchen-habitat"
+gem "kitchen-vagrant"
+```
+
+...then run `bundle install`.
+
+## Quick Start
+
+Run a package straight from the depot:
+
+```yaml
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: habitat
+  hab_license: accept
+  package_origin: core
+  package_name: redis
+
+platforms:
+  - name: ubuntu-22.04
+
+suites:
+  - name: default
+```
+
+Then:
+
+```sh
+cinc kitchen converge
+```
+
+Or run the whole cycle:
+
+```sh
+cinc kitchen test
+```
+
+`hab_license: accept` is required before Habitat will run — see
+[the Chef license documentation](https://docs.chef.io/chef_license_accept.html#habitat).
 
 ## Configuration Settings
 
-* `hab_license`: Habitat license acceptance type (for more information please read the [chef license documentation](https://docs.chef.io/chef_license_accept.html#habitat)).
-* `hab_version`: The version of habitat to be used in test kitchen.
+All options below are set under the `provisioner:` key in `kitchen.yml`, or per suite under
+`suites[].provisioner:`.
+
+### General
+
+* `hab_license`
+  * Habitat license acceptance. Set to `accept` to run at all.
+  * See the [Chef license documentation](https://docs.chef.io/chef_license_accept.html#habitat).
+  * Defaults to `nil`
+* `hab_version`
+  * Version of the `hab` CLI to install on the instance.
+  * Defaults to `latest`
+* `hab_channel`
+  * Release channel the `hab` CLI itself is installed from.
+  * Defaults to `stable`
+* `root_path`
+  * Directory on the instance used to stage artifacts and configuration.
+  * Defaults to the driver's sandbox path.
 
 ### Depot settings
 
@@ -40,16 +126,19 @@ You'll need the test-kitchen & kitchen-habitat gems installed in your system, al
   * Artifact package name for a custom supervisor to run
   * Used to upload and test a local supervisor.
   * Package should be located in the `results_directory`
-  * Defaults to `nil
+  * Defaults to `nil`
 * `hab_sup_listen_http`
   * Port for the supervisor's sidecar to listen on.
   * Defaults to `nil`
 * `hab_sup_listen_gossip`
   * Port for the supervisor's gossip communication
   * Defaults to `nil`
+* `hab_sup_listen_ctl`
+  * Listen address for the supervisor's control gateway (`--listen-ctl`).
+  * Defaults to `nil`
 * `hab_sup_group`
-  * Service group for the supervisor to belong do.
-  * Default is `default`
+  * Service group for the supervisor to belong to.
+  * Defaults to `nil`, which leaves the supervisor in its own `default` group.
 * `hab_sup_bind`
   * Service group for the supervisor to bind to.
   * Default is `[]`
@@ -69,7 +158,7 @@ You'll need the test-kitchen & kitchen-habitat gems installed in your system, al
   * Example - `core-jq-static-1.5-20170127185151-x86_64-linux.hart`
   * Defaults to `nil`
 * `results_directory`
-  * Directory (relative to the location of the .kitchen.yml) containing package artifacts (harts) to copy to the remote system
+  * Directory (relative to the location of `kitchen.yml`) containing package artifacts (harts) to copy to the remote system
   * Defaults to checking the local directory for a `results` directory, then its parent (`../results`) and grandparent (`../../results`), which should accommodate most studio layouts.
 * `package_origin`
   * Origin for the package to run.
@@ -89,6 +178,13 @@ You'll need the test-kitchen & kitchen-habitat gems installed in your system, al
 * `service_update_strategy`
   * Describes how package updates are to be applied.  Valid values are `nil`, `at-once`, `rolling`.
   * Default is `nil`, which does not check for package updates.
+* `channel`
+  * Release channel the package under test is installed from and loaded with.
+  * Defaults to `stable`
+* `service_load_timeout`
+  * Seconds to wait for the service to come up after it is loaded, before failing the converge.
+  * Raise this for services that are slow to start.
+  * Defaults to `300`
 * `config_directory`
   * Directory containing a user.toml or/and a default.toml, hooks, and configuration files to be passed to the service under test.
   * Defaults to `nil`
@@ -290,3 +386,19 @@ suites:
       inspec_tests:
         - tests
 ```
+
+## Using with Chef
+
+This provisioner is not tied to Cinc, and it does not install Cinc or Chef on the instance — it installs the Habitat
+supervisor and runs your package. The commands above use Cinc Workstation; with
+[Chef Workstation](https://www.chef.io/downloads/tools/workstation) run `kitchen` instead of `cinc kitchen`. No
+provisioner configuration changes are needed.
+
+## Contributing
+
+Bug reports and pull requests are welcome on [GitHub](https://github.com/test-kitchen/kitchen-habitat). See
+[CONTRIBUTING.md](CONTRIBUTING.md) for development setup, how to run the tests, and the release process.
+
+## License
+
+Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## What

Restructures `README.md` around a new user's path, fills in five undocumented options, fixes the broken CI badge, and adds a `CONTRIBUTING.md`.

## Broken badge

The CI badge was:

```text
[![CI](https://github.com/test-kitchen/kitchen-habitat/workflows/CI/badge.svg?branch=master)](...)
```

There is no workflow named `CI` and no `master` branch, so that URL returns **no SVG title at all** — the badge was simply dead. The real workflows are `unit.yml` ("Unit") and `linters.yml` ("linters"), so both now have badges on the modern `/actions/workflows/...` URLs.

⚠️ Worth knowing: `linters` is currently **failing on main**, independent of this PR. The badge will show that honestly once merged.

## Undocumented options

Five options were missing from the docs entirely:

- **`channel`** (default `stable`) — the channel the package under test is installed from. It *appears in one of the existing examples* but was never documented
- **`hab_channel`** (default `stable`) — the channel the `hab` CLI itself is installed from. Easy to confuse with `channel`, so both are now described in terms of what they affect
- **`service_load_timeout`** (default `300`) — the wait for the service to come up. This is the usual cause of a converge that hangs then fails, and there was no documented knob for it
- **`hab_sup_listen_ctl`** — supervisor control gateway address, alongside the other two listen options
- **`root_path`** — staging directory on the instance

All 35 `default_config` keys are now documented.

## Corrections

- **`hab_sup_group`** was documented as defaulting to `default`; it actually defaults to `nil` (the supervisor then uses its own `default` group). Now stated accurately
- `hab_sup_artifact_name` had a truncated code span (`Command line interface to a user's defaults.
Syntax:

'defaults' [-currentHost | -host <hostname>] followed by one of the following:

  read                                 shows all defaults
  read <domain>                        shows defaults for given domain
  read <domain> <key>                  shows defaults for given domain, key

  read-type <domain> <key>             shows the type for the given domain, key

  write <domain> <domain_rep>          writes domain (overwrites existing)
  write <domain> <key> <value>         writes key for domain

  rename <domain> <old_key> <new_key>  renames old_key to new_key

  delete <domain>                      deletes domain
  delete <domain> <key>                deletes key in domain
  delete-all <domain>                  deletes the domain from all containers
  delete-all <domain> Key>             deletes key in domain from all containers

  import <domain> <path to plist>      writes the plist at path to domain
  import <domain> -                    writes a plist from stdin to domain
  export <domain> <path to plist>      saves domain as a binary plist to path
  export <domain> -                    writes domain as an xml plist to stdout
  domains                              lists all domains
  find <word>                          lists all entries containing word
  help                                 print this help

<domain> is ( <domain_name> | -app <application_name> | -globalDomain )
         or a path to a file omitting the '.plist' extension

<value> is one of:
  <value_rep>
  -string <string_value>
  -data <hex_digits>
  -int[eger] <integer_value>
  -float  <floating-point_value>
  -bool[ean] (true | false | yes | no)
  -date <date_rep>
  -array <value1> <value2> ...
  -array-add <value1> <value2> ...
  -dict <key1> <value1> <key2> <value2> ...
  -dict-add <key1> <value1> ...nil  with no closing backtick) that broke the rendering of the rest of that bullet
- `.kitchen.yml` → `kitchen.yml`

## README additions

- What the provisioner actually does, requirements, and installation
- A working quick start — including `hab_license: accept`, without which Habitat won't run at all, and which the old README mentioned only in passing in an option description
- A "Using with Chef" note: worth saying explicitly that this provisioner installs neither Cinc nor Chef on the instance

The existing examples are all preserved.

## CONTRIBUTING.md

New file: issue reporting, dev setup, `bundle exec rake test`/`style`, a note that the unit tests only assert on generated shell/PowerShell, and a manual-testing checklist covering the paths that differ (depot vs local artifact, Linux vs Windows, multi-service with `hab_sup_peer`/`hab_sup_bind`).

Also adds the standard `.markdownlint.yaml` used by the other test-kitchen repos.

Docs only — no code changes.