### PR TITLE
chore: backfill missing changelog history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,145 @@
+## Unreleased
+
+* Optimize our requires ([86c4c66](https://github.com/test-kitchen/kitchen-habitat/commit/86c4c66))
+* Test on Ruby 3.0 and cache gem installs ([#48](https://github.com/test-kitchen/kitchen-habitat/pull/48)) ([5ff9c75](https://github.com/test-kitchen/kitchen-habitat/commit/5ff9c75))
+* Use a more standard test setup ([#49](https://github.com/test-kitchen/kitchen-habitat/pull/49)) ([3fa19c5](https://github.com/test-kitchen/kitchen-habitat/commit/3fa19c5))
+* Require Ruby 2.5+ ([#50](https://github.com/test-kitchen/kitchen-habitat/pull/50)) ([446aa48](https://github.com/test-kitchen/kitchen-habitat/commit/446aa48))
+* Update chefstyle requirement from =1.5.9 to 1.6.1 ([#51](https://github.com/test-kitchen/kitchen-habitat/pull/51)) ([429b918](https://github.com/test-kitchen/kitchen-habitat/commit/429b918))
+* Update chefstyle requirement from 1.6.1 to 1.6.2 ([#52](https://github.com/test-kitchen/kitchen-habitat/pull/52)) ([8db133b](https://github.com/test-kitchen/kitchen-habitat/commit/8db133b))
+* Fix linting error ([1a77da3](https://github.com/test-kitchen/kitchen-habitat/commit/1a77da3))
+* Update chefstyle requirement from 1.6.2 to 1.7.1 ([#53](https://github.com/test-kitchen/kitchen-habitat/pull/53)) ([60fa759](https://github.com/test-kitchen/kitchen-habitat/commit/60fa759))
+* Update chefstyle requirement from 1.7.1 to 1.7.2 ([#54](https://github.com/test-kitchen/kitchen-habitat/pull/54)) ([13d1814](https://github.com/test-kitchen/kitchen-habitat/commit/13d1814))
+* Update chefstyle requirement from 1.7.2 to 1.7.4 ([#55](https://github.com/test-kitchen/kitchen-habitat/pull/55)) ([f815c1f](https://github.com/test-kitchen/kitchen-habitat/commit/f815c1f))
+* Update chefstyle requirement from 1.7.4 to 1.7.5 ([#56](https://github.com/test-kitchen/kitchen-habitat/pull/56)) ([0b3e565](https://github.com/test-kitchen/kitchen-habitat/commit/0b3e565))
+* Update chefstyle requirement from 1.7.5 to 2.0.4 ([#59](https://github.com/test-kitchen/kitchen-habitat/pull/59)) ([1226df8](https://github.com/test-kitchen/kitchen-habitat/commit/1226df8))
+* Upgrade to GitHub-native Dependabot ([#57](https://github.com/test-kitchen/kitchen-habitat/pull/57)) ([0afd07a](https://github.com/test-kitchen/kitchen-habitat/commit/0afd07a))
+* Update chefstyle requirement from 2.0.4 to 2.0.5 ([#60](https://github.com/test-kitchen/kitchen-habitat/pull/60)) ([83a4ae2](https://github.com/test-kitchen/kitchen-habitat/commit/83a4ae2))
+* Support Test Kitchen 3.0 ([#61](https://github.com/test-kitchen/kitchen-habitat/pull/61)) ([9e26c05](https://github.com/test-kitchen/kitchen-habitat/commit/9e26c05))
+* Update chefstyle requirement from 2.0.5 to 2.0.9 ([#65](https://github.com/test-kitchen/kitchen-habitat/pull/65)) ([a0f11ab](https://github.com/test-kitchen/kitchen-habitat/commit/a0f11ab))
+* Update chefstyle requirement from 2.0.9 to 2.1.0 ([#66](https://github.com/test-kitchen/kitchen-habitat/pull/66)) ([1dfc637](https://github.com/test-kitchen/kitchen-habitat/commit/1dfc637))
+* Update chefstyle requirement from 2.1.0 to 2.1.1 ([#67](https://github.com/test-kitchen/kitchen-habitat/pull/67)) ([c72cad7](https://github.com/test-kitchen/kitchen-habitat/commit/c72cad7))
+* Update chefstyle requirement from 2.1.1 to 2.1.2 ([#68](https://github.com/test-kitchen/kitchen-habitat/pull/68)) ([a69d77a](https://github.com/test-kitchen/kitchen-habitat/commit/a69d77a))
+* Update chefstyle requirement from 2.1.2 to 2.2.0 ([#70](https://github.com/test-kitchen/kitchen-habitat/pull/70)) ([2e83f89](https://github.com/test-kitchen/kitchen-habitat/commit/2e83f89))
+* Update chefstyle requirement from 2.2.0 to 2.2.2 ([#72](https://github.com/test-kitchen/kitchen-habitat/pull/72)) ([f3a4d0d](https://github.com/test-kitchen/kitchen-habitat/commit/f3a4d0d))
+* Configure Renovate ([#74](https://github.com/test-kitchen/kitchen-habitat/pull/74)) ([8a1f07c](https://github.com/test-kitchen/kitchen-habitat/commit/8a1f07c))
+* Update dependency chefstyle to v2.2.3 ([#75](https://github.com/test-kitchen/kitchen-habitat/pull/75)) ([2cf1482](https://github.com/test-kitchen/kitchen-habitat/commit/2cf1482))
+* Update actions/checkout action to v4 ([#76](https://github.com/test-kitchen/kitchen-habitat/pull/76)) ([6db8f49](https://github.com/test-kitchen/kitchen-habitat/commit/6db8f49))
+* fix: bump tk dep to allow tk 4 ([#80](https://github.com/test-kitchen/kitchen-habitat/pull/80)) ([cec37b6](https://github.com/test-kitchen/kitchen-habitat/commit/cec37b6))
+* chore(deps): update actions/checkout action to v6 ([#79](https://github.com/test-kitchen/kitchen-habitat/pull/79)) ([8a0162e](https://github.com/test-kitchen/kitchen-habitat/commit/8a0162e))
+* Fix typos ([#82](https://github.com/test-kitchen/kitchen-habitat/pull/82)) ([e91016f](https://github.com/test-kitchen/kitchen-habitat/commit/e91016f))
+* Update actions/checkout action to v7 ([#81](https://github.com/test-kitchen/kitchen-habitat/pull/81)) ([be998aa](https://github.com/test-kitchen/kitchen-habitat/commit/be998aa))
+* Add release-please configuration ([#85](https://github.com/test-kitchen/kitchen-habitat/pull/85)) ([d14e80a](https://github.com/test-kitchen/kitchen-habitat/commit/d14e80a))
+* Require Ruby 3.1+ and modernize CI ([#83](https://github.com/test-kitchen/kitchen-habitat/pull/83)) ([6810b4b](https://github.com/test-kitchen/kitchen-habitat/commit/6810b4b))
+
+## [0.12.1](https://github.com/test-kitchen/kitchen-habitat/compare/v0.11.2...v0.12.1) (2020-07-29)
+
+* remove dupe gems & update authors ([#40](https://github.com/test-kitchen/kitchen-habitat/pull/40)) ([89abf36](https://github.com/test-kitchen/kitchen-habitat/commit/89abf36))
+* Expand ruby version testing ([#42](https://github.com/test-kitchen/kitchen-habitat/pull/42)) ([d1e55c6](https://github.com/test-kitchen/kitchen-habitat/commit/d1e55c6))
+* test with GitHub Actions ([#45](https://github.com/test-kitchen/kitchen-habitat/pull/45)) ([cf6a01f](https://github.com/test-kitchen/kitchen-habitat/commit/cf6a01f))
+* remove Travis CI (‘-‘*ゞ ([#46](https://github.com/test-kitchen/kitchen-habitat/pull/46)) ([85e0051](https://github.com/test-kitchen/kitchen-habitat/commit/85e0051))
+* use GitHub Actions badge in the README ([#47](https://github.com/test-kitchen/kitchen-habitat/pull/47)) ([6161fe4](https://github.com/test-kitchen/kitchen-habitat/commit/6161fe4))
+* Update provisioner ([#43](https://github.com/test-kitchen/kitchen-habitat/pull/43)) ([80db669](https://github.com/test-kitchen/kitchen-habitat/commit/80db669))
+* Uping version for https://github.com/test-kitchen/kitchen-habitat/pull/43 merge ([a8dad92](https://github.com/test-kitchen/kitchen-habitat/commit/a8dad92))
+
+## [0.11.2](https://github.com/test-kitchen/kitchen-habitat/compare/v0.11.1...v0.11.2) (2019-12-02)
+
+* adds license acceptance variable to config ([#36](https://github.com/test-kitchen/kitchen-habitat/pull/36)) ([633a488](https://github.com/test-kitchen/kitchen-habitat/commit/633a488))
+
+## [0.11.1](https://github.com/test-kitchen/kitchen-habitat/compare/v0.11.0...v0.11.1) (2019-11-12)
+
+* Loosen the Test Kitchen dep + resolve Chefstyle warnings ([#34](https://github.com/test-kitchen/kitchen-habitat/pull/34)) ([cd871d7](https://github.com/test-kitchen/kitchen-habitat/commit/cd871d7))
+* bump to 0.11.1 & appease ChefStyle ([#38](https://github.com/test-kitchen/kitchen-habitat/pull/38)) ([e7cdefd](https://github.com/test-kitchen/kitchen-habitat/commit/e7cdefd))
+
+## [0.11.0](https://github.com/test-kitchen/kitchen-habitat/compare/v0.10.0...v0.11.0) (2018-09-28)
+
+* install specific version of habitat ([#30](https://github.com/test-kitchen/kitchen-habitat/pull/30)) ([9c44e71](https://github.com/test-kitchen/kitchen-habitat/commit/9c44e71))
+* force supervisor to run ([#29](https://github.com/test-kitchen/kitchen-habitat/pull/29)) ([54772b6](https://github.com/test-kitchen/kitchen-habitat/commit/54772b6))
+
+## [0.10.0](https://github.com/test-kitchen/kitchen-habitat/compare/v0.9.0...v0.10.0) (2018-08-16)
+
+* Use package ident regex to detect artifact name ([#25](https://github.com/test-kitchen/kitchen-habitat/pull/25)) ([b5f1871](https://github.com/test-kitchen/kitchen-habitat/commit/b5f1871))
+* add support for supervisor --ring option ([#26](https://github.com/test-kitchen/kitchen-habitat/pull/26)) ([8ae8032](https://github.com/test-kitchen/kitchen-habitat/commit/8ae8032))
+
+## [0.9.0](https://github.com/test-kitchen/kitchen-habitat/compare/v0.8.1...v0.9.0) (2018-07-16)
+
+* Add Support for Remote Supervisor Control ([#21](https://github.com/test-kitchen/kitchen-habitat/pull/21)) ([db669f7](https://github.com/test-kitchen/kitchen-habitat/commit/db669f7))
+
+## [0.8.1](https://github.com/test-kitchen/kitchen-habitat/compare/v0.8.0...v0.8.1) (2018-07-12)
+
+* fixing style failure ([104d9d3](https://github.com/test-kitchen/kitchen-habitat/commit/104d9d3))
+* Add unit tests ([#17](https://github.com/test-kitchen/kitchen-habitat/pull/17)) ([6f0fbcd](https://github.com/test-kitchen/kitchen-habitat/commit/6f0fbcd))
+* #16 Adding install and init command tests ([#19](https://github.com/test-kitchen/kitchen-habitat/pull/19)) ([9f10b3a](https://github.com/test-kitchen/kitchen-habitat/commit/9f10b3a))
+* Depot url now sets HAB_BLDR_URL env var ([#20](https://github.com/test-kitchen/kitchen-habitat/pull/20)) ([e7cc115](https://github.com/test-kitchen/kitchen-habitat/commit/e7cc115))
+* releasing bug fix for #18 allowing alternative depot usage ([4db6074](https://github.com/test-kitchen/kitchen-habitat/commit/4db6074))
+
+## [0.8.0](https://github.com/test-kitchen/kitchen-habitat/compare/v0.7.0...v0.8.0) (2018-06-21)
+
+* Updates to support 0.57.0 ([#14](https://github.com/test-kitchen/kitchen-habitat/pull/14)) ([2f57e52](https://github.com/test-kitchen/kitchen-habitat/commit/2f57e52))
+
+## [0.7.0](https://github.com/test-kitchen/kitchen-habitat/compare/v0.6.1...v0.7.0) (2017-11-10)
+
+* update example ([7b0c8bf](https://github.com/test-kitchen/kitchen-habitat/commit/7b0c8bf))
+* minor readme updates ([#10](https://github.com/test-kitchen/kitchen-habitat/pull/10)) ([cee5349](https://github.com/test-kitchen/kitchen-habitat/commit/cee5349))
+* Launcher support ([#11](https://github.com/test-kitchen/kitchen-habitat/pull/11)) ([b70cdb7](https://github.com/test-kitchen/kitchen-habitat/commit/b70cdb7))
+
+## [0.6.1](https://github.com/test-kitchen/kitchen-habitat/compare/v0.6.0...v0.6.1) (2017-03-28)
+
+* updated docs ([bebb238](https://github.com/test-kitchen/kitchen-habitat/commit/bebb238))
+* fix some guards around latest artifact install ([2627430](https://github.com/test-kitchen/kitchen-habitat/commit/2627430))
+
+## [0.6.0](https://github.com/test-kitchen/kitchen-habitat/compare/v0.5.3...v0.6.0) (2017-03-24)
+
+* Merge branch 'bdangit-add-get-latest-artifact' ([3ab1832](https://github.com/test-kitchen/kitchen-habitat/commit/3ab1832))
+
+## [0.5.3](https://github.com/test-kitchen/kitchen-habitat/compare/v0.5.2...v0.5.3) (2017-03-23)
+
+* oops, left a bit of logging ([5a65e35](https://github.com/test-kitchen/kitchen-habitat/commit/5a65e35))
+
+## [0.5.2](https://github.com/test-kitchen/kitchen-habitat/compare/v0.5.1...v0.5.2) (2017-03-23)
+
+* force creation of /tmp/kitchen/config to get user.toml in the right place ([12b93d1](https://github.com/test-kitchen/kitchen-habitat/commit/12b93d1))
+
+## [0.5.1](https://github.com/test-kitchen/kitchen-habitat/compare/v0.5.0...v0.5.1) (2017-03-23)
+
+* fix --config-from file copy behavior (guard for user toml copy) ([63958fb](https://github.com/test-kitchen/kitchen-habitat/commit/63958fb))
+
+## [0.5.0](https://github.com/test-kitchen/kitchen-habitat/compare/v0.4.0...v0.5.0) (2017-03-23)
+
+* Update README.md ([9dc842e](https://github.com/test-kitchen/kitchen-habitat/commit/9dc842e))
+* Fix some typos and improve example ([#6](https://github.com/test-kitchen/kitchen-habitat/pull/6)) ([50a17d0](https://github.com/test-kitchen/kitchen-habitat/commit/50a17d0))
+* Make user toml copy actually work ([#8](https://github.com/test-kitchen/kitchen-habitat/pull/8)) ([056a441](https://github.com/test-kitchen/kitchen-habitat/commit/056a441))
+
+## [0.4.0](https://github.com/test-kitchen/kitchen-habitat/compare/v0.3.1...v0.4.0) (2017-03-06)
+
+* Change "timestamp" to "release" ([#3](https://github.com/test-kitchen/kitchen-habitat/pull/3)) ([f4e3b4e](https://github.com/test-kitchen/kitchen-habitat/commit/f4e3b4e))
+* Fix typo ([#1](https://github.com/test-kitchen/kitchen-habitat/pull/1)) ([16bab5f](https://github.com/test-kitchen/kitchen-habitat/commit/16bab5f))
+* Replace backslashes with slashes. ([#2](https://github.com/test-kitchen/kitchen-habitat/pull/2)) ([ad7627e](https://github.com/test-kitchen/kitchen-habitat/commit/ad7627e))
+
+## [0.3.1](https://github.com/test-kitchen/kitchen-habitat/compare/v0.3.0...v0.3.1) (2017-03-05)
+
+* missed a } when changing things up ([596cbf1](https://github.com/test-kitchen/kitchen-habitat/commit/596cbf1))
+
+## [0.3.0](https://github.com/test-kitchen/kitchen-habitat/compare/v0.2.4...v0.3.0) (2017-03-04)
+
+* Add support for groups, service topologies, and update strategies ([e511699](https://github.com/test-kitchen/kitchen-habitat/commit/e511699))
+
+## [0.2.4](https://github.com/test-kitchen/kitchen-habitat/compare/v0.2.1...v0.2.4) (2017-03-04)
+
+* add cleanup for previous background on reconverge ([bcc0faa](https://github.com/test-kitchen/kitchen-habitat/commit/bcc0faa))
+* fix bash syntax for starting and cleanup ([51c7f12](https://github.com/test-kitchen/kitchen-habitat/commit/51c7f12))
+* oh, I hate bash ([e9ffc81](https://github.com/test-kitchen/kitchen-habitat/commit/e9ffc81))
+
+## [0.2.1](https://github.com/test-kitchen/kitchen-habitat/compare/v0.2.0...v0.2.1) (2017-03-03)
+
+* needed a space in the binding ([2ee4379](https://github.com/test-kitchen/kitchen-habitat/commit/2ee4379))
+
+## [0.2.0](https://github.com/test-kitchen/kitchen-habitat/compare/v0.1.0...v0.2.0) (2017-03-03)
+
+* more options ([189c242](https://github.com/test-kitchen/kitchen-habitat/commit/189c242))
+
+## 0.1.0 (2017-03-02)
+
+* first commit ([f809a49](https://github.com/test-kitchen/kitchen-habitat/commit/f809a49))
+* chefstyle ([1fd7ca4](https://github.com/test-kitchen/kitchen-habitat/commit/1fd7ca4))
+* More work in progress ([defe94b](https://github.com/test-kitchen/kitchen-habitat/commit/defe94b))
+* moving to the first release ([9cb7a29](https://github.com/test-kitchen/kitchen-habitat/commit/9cb7a29))


### PR DESCRIPTION
Backfills the changelog so every released version records all of its changes.

## What changed

- **Missing entries added.** These changelogs were generated by release-please, which only writes `feat:`, `fix:` and breaking changes. Everything typed `chore:`, `ci:`, `docs:`, `test:` or `refactor:` was silently dropped. Older versions predate conventional commits entirely and were never written up at all.
- **Entries use the PR title** where a change landed via a pull request, and link both the PR and the commit.
- **Unpublished versions removed.** Versions tagged in git but never published to RubyGems are no longer listed as releases. Their entries roll forward into the version that actually shipped them, so no change record is lost.
- Backfilled entries are grouped under `### Other Changes` where a section already used release-please headings, so they don't read as bug fixes.

RubyGems is treated as the source of truth for whether a release happened.

Nothing outside the changelog is touched, and the commit is a `chore:` so it won't trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
