### PR TITLE
fix: require test-kitchen 3.0 or newer

### DIFF
--- a/kitchen-habitat.gemspec
+++ b/kitchen-habitat.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 3.1"
 
-  s.add_dependency "test-kitchen", ">= 1.4", "< 5"
+  s.add_dependency "test-kitchen", ">= 3.0", "< 5"
 end


### PR DESCRIPTION
The dependency floor was stale:

```ruby
add_dependency "test-kitchen", ">= 1.4", "< 5"
```

Raised to the oldest release this plugin is actually expected to work with:

```ruby
add_dependency "test-kitchen", ">= 3.0", "< 5"
```

Test Kitchen 1.x and 2.x are both long end of life, the gem already declares `required_ruby_version >= 3.1`, and CI has never run against anything below the current release. The old floor let Bundler resolve a pairing nobody has ever tested.

The ``< 5`` ceiling is unchanged.

Verified: `rake test` 86 examples, 0 failures, `cookstyle --chefstyle` clean, `bundle check` satisfied.
