### PR TITLE
chore: drop the pry development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,10 +13,6 @@ group :docs do
   gem "yard"
 end
 
-group :debug do
-  gem "pry"
-end
-
 group :cookstyle do
   gem "cookstyle"
 end


### PR DESCRIPTION
`pry` and friends are interactive-console conveniences. Nothing in `lib/`, `spec/`, the Rakefile, or CI references them — no `require "pry"`, no `binding.pry`, no rake or workflow step that invokes them. They only ever slow down `bundle install` for contributors.

Anyone who wants a REPL mid-debug can still `gem install pry` locally, or use `debug`, which ships with Ruby 3.1+ (the floor this gem already requires).