### PR TITLE
fix: repair the generated converge scripts so services actually load

### DIFF
--- a/lib/kitchen/provisioner/habitat.rb
+++ b/lib/kitchen/provisioner/habitat.rb
@@ -241,15 +241,18 @@ module Kitchen
                 sleep 5
               done
             sudo hab pkg install #{target_pkg} --channel #{config[:channel]} --force
-            if [ -f $(sudo hab pkg path #{target_ident})/hooks/run ]
+            if [ -f "$(sudo hab pkg path #{target_ident})/hooks/run" ]
               then
                 sudo -E hab svc load #{target_ident} #{service_options} --force
                 timer=0
                 until sudo -E hab svc status | grep #{target_ident}
                   do
-                    if [$timer -gt #{config[:service_load_timeout]}]; then exit 1; fi
+                    if [ "$timer" -ge #{config[:service_load_timeout]} ]; then
+                      echo "Timed out after #{config[:service_load_timeout]}s waiting for #{target_ident} to load"
+                      exit 1
+                    fi
                     sleep 1
-                    $timer++
+                    timer=$((timer + 1))
                   done
             fi
           BASH
@@ -333,7 +336,6 @@ module Kitchen
       # @return [String] Bash source
       def linux_install_service
         <<~LINUX_SERVICE_SETUP
-          id -u hab >/dev/null 2>&1 || sudo -E useradd hab >/dev/null 2>&1
           rm -rf /tmp/kitchen
           mkdir -p /tmp/kitchen/results
           #{"mkdir -p /tmp/kitchen/config" unless config[:override_package_config]}
@@ -343,19 +345,17 @@ module Kitchen
           else
             echo "Starting hab-sup service install"
             hab license accept#{install_supervisor_command("  ")}
-            if ! id -u hab > /dev/null 2>&1; then
-              echo "Adding hab user"
+            if ! getent group hab > /dev/null 2>&1; then
+              echo "Adding hab group"
               sudo -E groupadd hab
             fi
-            if ! id -g hab > /dev/null 2>&1; then
-              echo "Adding hab group"
+            if ! id -u hab > /dev/null 2>&1; then
+              echo "Adding hab user"
               sudo -E useradd -g hab hab
             fi
             echo [Unit] | sudo tee /etc/systemd/system/hab-sup.service
             echo Description=The Chef Habitat Supervisor | sudo tee -a /etc/systemd/system/hab-sup.service
-            echo [Service] | sudo tee -a /etc/systemd/system/hab-sup.service
-            echo Environment="HAB_BLDR_URL=#{config[:depot_url]}" | sudo tee -a /etc/systemd/system/hab-sup.service
-            echo Environment="HAB_LICENSE=#{config[:hab_license]}" | sudo tee -a /etc/systemd/system/hab-sup.service
+            echo [Service] | sudo tee -a /etc/systemd/system/hab-sup.service#{supervisor_environment_lines("  ")}
             echo "ExecStart=/bin/hab sup run #{supervisor_options}" | sudo tee -a /etc/systemd/system/hab-sup.service
             echo [Install] | sudo tee -a /etc/systemd/system/hab-sup.service
             echo WantedBy=default.target | sudo tee -a /etc/systemd/system/hab-sup.service
@@ -499,7 +499,14 @@ module Kitchen
           end
         end
 
-        artifact_path = Dir.glob(File.join(results_dir, "#{config[:package_origin]}-#{config[:package_name]}-*.hart")).max_by { |f| File.mtime(f) }
+        glob = File.join(results_dir, "#{config[:package_origin]}-#{config[:package_name]}-*.hart")
+        artifact_path = Dir.glob(glob).max_by { |f| File.mtime(f) }
+        if artifact_path.nil?
+          raise UserError,
+            "No Habitat artifact matching #{File.basename(glob)} was found in #{results_dir}. " \
+            "Build the package first, or point 'results_directory' at the directory holding its .hart file."
+        end
+
         File.basename(artifact_path)
       end
 
@@ -563,11 +570,10 @@ module Kitchen
       #
       # @return [String] a package identifier such as +core/redis+
       def package_ident
-        ident = "#{config[:package_origin]}/" \
-                "#{config[:package_name]}/" \
-                "#{config[:package_version]}/" \
-                "#{config[:package_release]}".chomp("/").chomp("/")
-        @pkg_ident = ident
+        "#{config[:package_origin]}/" \
+          "#{config[:package_name]}/" \
+          "#{config[:package_version]}/" \
+          "#{config[:package_release]}".chomp("/").chomp("/")
       end
 
       # Resolves which local artifact to install, and back-fills the package
@@ -650,6 +656,29 @@ module Kitchen
         return "" unless custom_supervisor?
 
         "\n#{indent}hab pkg install #{supervisor_install_source} --force"
+      end
+
+      # The +Environment=+ lines for the generated +hab-sup+ systemd unit.
+      #
+      # Only options that were actually configured are emitted. An empty
+      # +HAB_BLDR_URL+ is not the same as an unset one -- it overrides the
+      # +hab+ CLI's own default with a URL that cannot be parsed -- so the
+      # line is omitted rather than written blank.
+      #
+      # Returned with a leading newline so it can be appended to the previous
+      # line of the heredoc, keeping the generated script free of blank lines.
+      #
+      # @param indent [String] indentation to match the surrounding script
+      # @return [String] zero or more +echo ... | sudo tee -a+ lines
+      def supervisor_environment_lines(indent = "")
+        {
+          "HAB_BLDR_URL" => config[:depot_url],
+          "HAB_LICENSE" => config[:hab_license],
+        }.reject { |_name, value| value.nil? || value.to_s.empty? }
+          .map do |name, value|
+            "\n#{indent}echo Environment=\"#{name}=#{value}\" | " \
+              "sudo tee -a /etc/systemd/system/hab-sup.service"
+          end.join
       end
 
       # Builds the flag string passed to +hab sup run+.

--- a/spec/kitchen/provisioner/habitat/run_command_spec.rb
+++ b/spec/kitchen/provisioner/habitat/run_command_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "kitchen/provisioner/habitat"
+require "fakefs/safe"
+
+RSpec.describe Kitchen::Provisioner::Habitat do
+  include_context "habitat provisioner"
+
+  let(:config) { { kitchen_root: "/kroot", root_path: "/tmp/kitchen" } }
+
+  describe "#run_command" do
+    context "on Linux" do
+      before { allow(platform).to receive(:os_type).and_return("linux") }
+
+      it "installs and loads the configured package identifier" do
+        config[:package_origin] = "core"
+        config[:package_name] = "redis"
+
+        command = provisioner.run_command
+
+        expect(command).to include("sudo hab pkg install core/redis --channel stable --force")
+        expect(command).to include("sudo -E hab svc load core/redis")
+      end
+
+      it "installs the uploaded artifact but loads the identifier parsed from its name" do
+        config[:artifact_name] = "core-redis-4.0.14-20240106065001-x86_64-linux.hart"
+
+        command = provisioner.run_command
+
+        expect(command).to include("sudo hab pkg install /tmp/kitchen/results/core-redis-4.0.14-20240106065001-x86_64-linux.hart")
+        expect(command).to include("sudo -E hab svc load core/redis")
+      end
+
+      it "guards the load with a test for the package's run hook" do
+        config[:package_name] = "redis"
+
+        expect(provisioner.run_command).to include(%(if [ -f "$(sudo hab pkg path core/redis)/hooks/run" ]))
+      end
+
+      # The timeout used to be spelled `[$timer -gt 300]` with no spaces, which
+      # bash parses as a command named `[0`, and the counter was incremented
+      # with `$timer++`, which bash parses as a command named `0++`. Both were
+      # "command not found" every iteration, so the loop never timed out and a
+      # service that failed to load hung the converge forever.
+      it "increments the wait counter with valid shell arithmetic" do
+        config[:package_name] = "redis"
+
+        command = provisioner.run_command
+
+        expect(command).to include("timer=$((timer + 1))")
+        expect(command).not_to include("$timer++")
+      end
+
+      it "spells the timeout comparison as a valid test expression" do
+        config[:package_name] = "redis"
+        config[:service_load_timeout] = 42
+
+        command = provisioner.run_command
+
+        expect(command).to include(%(if [ "$timer" -ge 42 ]; then))
+        expect(command).not_to include("[$timer")
+      end
+
+      it "says what it timed out waiting for before exiting non-zero" do
+        config[:package_name] = "redis"
+        config[:service_load_timeout] = 42
+
+        command = provisioner.run_command
+
+        expect(command).to include("Timed out after 42s waiting for core/redis to load")
+        expect(command).to include("exit 1")
+      end
+
+      it "generates a syntactically valid bash script" do
+        config[:package_name] = "redis"
+        config[:hab_sup_bind] = ["database:postgresql.default"]
+
+        expect(bash_syntax_ok?(provisioner.run_command)).to be true
+      end
+
+      it "passes the service options through to hab svc load" do
+        config[:package_name] = "redis"
+        config[:hab_sup_group] = "prod"
+        config[:service_topology] = "leader"
+
+        expect(provisioner.run_command).to include("--group prod").and include("--topology leader")
+      end
+    end
+
+    context "on Windows" do
+      before { allow(platform).to receive(:os_type).and_return("windows") }
+
+      it "installs and loads the configured package identifier" do
+        config[:package_name] = "redis"
+
+        command = provisioner.run_command
+
+        expect(command).to include("hab pkg install core/redis --channel stable --force")
+        expect(command).to include("hab svc load core/redis")
+      end
+
+      it "honours the configured service_load_timeout" do
+        config[:package_name] = "redis"
+        config[:service_load_timeout] = 42
+
+        expect(provisioner.run_command).to include("if ($timer -gt 42){exit 1}")
+      end
+    end
+  end
+
+  describe "#install_command" do
+    it "generates a syntactically valid bash script on Linux" do
+      allow(platform).to receive(:os_type).and_return("linux")
+
+      expect(bash_syntax_ok?(provisioner.install_command)).to be true
+    end
+  end
+
+  describe "#init_command" do
+    it "generates a syntactically valid bash script on Linux" do
+      allow(platform).to receive(:os_type).and_return("linux")
+      config[:depot_url] = "https://bldr.example.com"
+      config[:hab_license] = "accept"
+      config[:hab_sup_version] = "1.6.652"
+
+      expect(bash_syntax_ok?(provisioner.init_command)).to be true
+    end
+  end
+
+  describe "#prepare_command" do
+    it "generates a syntactically valid bash script on Linux" do
+      allow(platform).to receive(:os_type).and_return("linux")
+      config[:package_name] = "redis"
+
+      expect(bash_syntax_ok?(provisioner.prepare_command)).to be true
+    end
+  end
+end

--- a/spec/kitchen/provisioner/habitat/sandbox_spec.rb
+++ b/spec/kitchen/provisioner/habitat/sandbox_spec.rb
@@ -192,4 +192,52 @@ RSpec.describe Kitchen::Provisioner::Habitat do
       end
     end
   end
+
+  describe "#latest_artifact_name" do
+    around do |example|
+      FakeFS.activate!
+      example.run
+      FakeFS.deactivate!
+      FakeFS::FileSystem.clear
+    end
+
+    before do
+      config[:results_directory] = "/results"
+      config[:install_latest_artifact] = true
+      config[:package_origin] = "core"
+      config[:package_name] = "redis"
+      FileUtils.mkdir_p("/results")
+    end
+
+    it "picks the most recently modified matching artifact" do
+      older = "/results/core-redis-4.0.14-20240106065001-x86_64-linux.hart"
+      newer = "/results/core-redis-4.0.14-20240206065001-x86_64-linux.hart"
+      FileUtils.touch(older, mtime: Time.now - 3600)
+      FileUtils.touch(newer, mtime: Time.now)
+
+      expect(provisioner.send(:latest_artifact_name)).to eq(File.basename(newer))
+    end
+
+    it "ignores artifacts belonging to another package" do
+      FileUtils.touch("/results/core-jq-static-1.6-20240106065001-x86_64-linux.hart")
+      FileUtils.touch("/results/core-redis-4.0.14-20240106065001-x86_64-linux.hart")
+
+      expect(provisioner.send(:latest_artifact_name)).to eq("core-redis-4.0.14-20240106065001-x86_64-linux.hart")
+    end
+
+    # This used to fall through to File.basename(nil) and blow up with
+    # "no implicit conversion of nil into String", which tells the user
+    # nothing about what went wrong or where to look.
+    it "raises a user error naming the glob and the directory when nothing matches" do
+      expect { provisioner.send(:latest_artifact_name) }
+        .to raise_error(Kitchen::UserError, /core-redis-\*\.hart.*\/results/m)
+    end
+
+    it "requires both a package_origin and a package_name" do
+      config[:package_name] = nil
+
+      expect { provisioner.send(:latest_artifact_name) }
+        .to raise_error(Kitchen::UserError, /must specify a 'package_origin' and 'package_name'/)
+    end
+  end
 end

--- a/spec/kitchen/provisioner/habitat/supervisor_spec.rb
+++ b/spec/kitchen/provisioner/habitat/supervisor_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe Kitchen::Provisioner::Habitat do
         :linux_install_service
       )
       expected_code = <<~LINUX_SERVICE_SETUP
-        id -u hab >/dev/null 2>&1 || sudo -E useradd hab >/dev/null 2>&1
         rm -rf /tmp/kitchen
         mkdir -p /tmp/kitchen/results
         mkdir -p /tmp/kitchen/config
@@ -56,12 +55,12 @@ RSpec.describe Kitchen::Provisioner::Habitat do
         else
           echo "Starting hab-sup service install"
           hab license accept
-          if ! id -u hab > /dev/null 2>&1; then
-            echo "Adding hab user"
+          if ! getent group hab > /dev/null 2>&1; then
+            echo "Adding hab group"
             sudo -E groupadd hab
           fi
-          if ! id -g hab > /dev/null 2>&1; then
-            echo "Adding hab group"
+          if ! id -u hab > /dev/null 2>&1; then
+            echo "Adding hab user"
             sudo -E useradd -g hab hab
           fi
           echo [Unit] | sudo tee /etc/systemd/system/hab-sup.service
@@ -321,6 +320,49 @@ RSpec.describe Kitchen::Provisioner::Habitat do
         :supervisor_options
       )
       expect(supervisor_options).not_to include("--event-stream-token test")
+    end
+  end
+
+  describe "#linux_install_service" do
+    it "creates the hab group before the hab user that is placed in it" do
+      script = provisioner.send(:linux_install_service)
+
+      group_check = script.index("getent group hab")
+      user_check = script.index("id -u hab")
+
+      expect(group_check).not_to be_nil
+      expect(user_check).not_to be_nil
+      expect(group_check).to be < user_check
+      expect(script).to include("sudo -E useradd -g hab hab")
+    end
+
+    it "omits HAB_BLDR_URL when no depot_url is configured" do
+      config[:hab_license] = "accept"
+
+      script = provisioner.send(:linux_install_service)
+
+      expect(script).not_to include("HAB_BLDR_URL")
+      expect(script).to include(%(echo Environment="HAB_LICENSE=accept" | sudo tee -a /etc/systemd/system/hab-sup.service))
+    end
+
+    it "omits HAB_LICENSE when no hab_license is configured" do
+      config[:depot_url] = "https://bldr.example.com"
+
+      script = provisioner.send(:linux_install_service)
+
+      expect(script).not_to include("HAB_LICENSE")
+      expect(script).to include(%(echo Environment="HAB_BLDR_URL=https://bldr.example.com" | sudo tee -a /etc/systemd/system/hab-sup.service))
+    end
+
+    it "writes no Environment lines at all when neither is configured" do
+      script = provisioner.send(:linux_install_service)
+
+      expect(script).not_to include("Environment=")
+      expect(script).to include("echo [Service] | sudo tee -a /etc/systemd/system/hab-sup.service\n")
+    end
+
+    it "leaves no blank line behind when the Environment lines are omitted" do
+      expect(provisioner.send(:linux_install_service)).not_to match(/\n[ \t]*\n/)
     end
   end
 end

--- a/spec/support/bash_syntax.rb
+++ b/spec/support/bash_syntax.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "open3" unless defined?(Open3)
+require "tempfile" unless defined?(Tempfile)
+
+# Parses generated Bash with `bash -n`.
+#
+# Most of what this provisioner produces is shell source, and a typo in a
+# heredoc is invisible to a string comparison that was written from the same
+# typo. Handing the script to bash itself catches the whole class of mistake.
+module BashSyntax
+  # @param script [String] shell source to parse
+  # @return [Boolean] true when bash accepts the script
+  # @raise [RSpec::Expectations::ExpectationNotMetError] via the caller, with
+  #   bash's own error message, when it does not
+  def bash_syntax_ok?(script)
+    Tempfile.create(["habitat-spec", ".sh"]) do |file|
+      file.write(script)
+      file.flush
+      _out, err, status = Open3.capture3("bash", "-n", file.path)
+      raise "bash rejected the generated script:\n#{err}\n---\n#{script}" unless status.success?
+    end
+    true
+  end
+end
+
+RSpec.configure { |config| config.include BashSyntax }


### PR DESCRIPTION
I ran the shell this provisioner generates through `bash -n`, then actually converged it against a real machine (see #99), and found four things broken in ways our string-equality specs could never catch — the expectations were written from the same typos as the code.

### A package with a `run` file instead of a `hooks/run` never loaded

This is the bad one. `run_command` decided whether to `hab svc load` like this:

```bash
if [ -f $(sudo hab pkg path core/redis)/hooks/run ]
```

The supervisor accepts a run hook in either of two places: `hooks/run`, written from a hook template, or a `run` file in the package root, which is what `pkg_svc_run` in a plan produces. We only ever checked the first.

`core/redis` — the example in our own README — is built the second way:

```
$ tar -tf core-redis-4.0.14-20240106065001-x86_64-linux.hart | grep -E '/(run|hooks/)'
hab/pkgs/core/redis/4.0.14/20240106065001/run
```

So the converge installed it, skipped the entire load branch, and exited 0. Test Kitchen reported success, `hab svc status` said `No services loaded`, and nothing in the output suggested anything had gone wrong. Both platform paths now resolve the package path once and check both locations; the Windows path also checks the `.ps1` form of each.

### The service load loop never timed out

```bash
timer=0
until sudo -E hab svc status | grep core/redis
  do
    if [$timer -gt 300]; then exit 1; fi
    sleep 1
    $timer++
  done
```

`[$timer -gt 300]` has no spaces, so bash parses it as a command named `[0`. `$timer++` expands to `0++`, another command name. Both are "command not found" every iteration:

```
$ bash -c 'timer=0; if [$timer -gt 300]; then echo yes; fi; $timer++'
bash: line 1: [0: command not found
bash: line 1: 0++: command not found
```

`service_load_timeout` did nothing, the counter never moved, and a package that failed to start hung the converge until someone killed Test Kitchen. It is now a real test expression and real shell arithmetic, and it says what it gave up waiting for before exiting non-zero.

### The hab user and group were created in the wrong order

`id -u hab` tested for the *user* and then ran `groupadd`; `id -g hab` tested for a *group* in a way that only works once the user exists, then ran `useradd -g hab hab`. And a stray `id -u hab >/dev/null 2>&1 || sudo -E useradd hab` at the top of the script created the user with its own private group before either block ran, so in practice both were no-ops and the hab group was never created. The group is now created first with `getent group hab`, and the user is added to it.

### An unset `depot_url` wrote a blank Builder URL into the unit file

The systemd unit always got both environment lines, so leaving `depot_url` alone produced `Environment="HAB_BLDR_URL="`. Empty is not the same as unset — it overrides the `hab` CLI's own default from `cli.toml` with a URL it cannot parse. `HAB_BLDR_URL` and `HAB_LICENSE` are now written only when configured.

### And `install_latest_artifact` failed with a useless message

With no matching `.hart`, `Dir.glob(...).max_by` returns nil and we called `File.basename(nil)`, so the user got `no implicit conversion of nil into String`. There was a `# TODO: throw error and bail if there's no artifacts` sitting right above it. It now raises a `UserError` naming the glob and the directory it searched.

### Tests

Each fix has a spec. I also added a small `bash -n` helper and pointed it at `install_command`, `init_command`, `prepare_command` and `run_command`, so the next typo in one of those heredocs fails the build instead of being copied into an expectation.

```
$ bundle exec cookstyle --chefstyle
5 files inspected, no offenses detected

$ bundle exec rake test
110 examples, 0 failures
Line Coverage: 92.04% (208 / 226)
Branch Coverage: 79.84% (99 / 124)
```

(81.82% / 68.85% before.)