### PR TITLE
test: cover the provisioner logic that had none

### DIFF
--- a/spec/kitchen/provisioner/habitat/config_spec.rb
+++ b/spec/kitchen/provisioner/habitat/config_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "kitchen/provisioner/habitat"
+
+RSpec.describe Kitchen::Provisioner::Habitat do
+  include_context "habitat provisioner"
+
+  # finalize_config! is the only place the package identity options are
+  # normalised, and everything downstream -- the ident passed to
+  # `hab pkg install`, the user.toml destination, the artifact glob -- assumes
+  # it has already run.
+  describe "#finalize_config!" do
+    # Referencing `provisioner` runs finalize_config! through Kitchen::Instance.
+    subject(:finalized) { provisioner.send(:config) }
+
+    context "when package_name is a bare name" do
+      let(:config) { { kitchen_root: "/kroot", package_name: "redis" } }
+
+      it "leaves the name and the default origin alone" do
+        expect(finalized[:package_name]).to eq("redis")
+        expect(finalized[:package_origin]).to eq("core")
+        expect(finalized[:package_version]).to be_nil
+        expect(finalized[:package_release]).to be_nil
+      end
+    end
+
+    context "when package_name is an origin/name pair" do
+      let(:config) { { kitchen_root: "/kroot", package_name: "mycorp/wildfly" } }
+
+      it "splits the origin out of the name" do
+        expect(finalized[:package_origin]).to eq("mycorp")
+        expect(finalized[:package_name]).to eq("wildfly")
+        expect(finalized[:package_version]).to be_nil
+        expect(finalized[:package_release]).to be_nil
+      end
+    end
+
+    context "when package_name is a fully qualified identifier" do
+      let(:config) do
+        { kitchen_root: "/kroot", package_name: "core/redis/4.0.14/20240106065001" }
+      end
+
+      it "splits all four parts out" do
+        expect(finalized[:package_origin]).to eq("core")
+        expect(finalized[:package_name]).to eq("redis")
+        expect(finalized[:package_version]).to eq("4.0.14")
+        expect(finalized[:package_release]).to eq("20240106065001")
+      end
+
+      it "rebuilds the same identifier" do
+        expect(provisioner.send(:package_ident)).to eq("core/redis/4.0.14/20240106065001")
+      end
+    end
+
+    context "when package_name is nil" do
+      let(:config) { { kitchen_root: "/kroot" } }
+
+      it "does not try to split it" do
+        expect(finalized[:package_name]).to be_nil
+        expect(finalized[:package_origin]).to eq("core")
+      end
+    end
+
+    context "when an artifact_name is given" do
+      let(:config) do
+        {
+          kitchen_root: "/kroot",
+          package_origin: "ignored",
+          package_name: "ignored",
+          artifact_name: "mycorp-wildfly-26.1.1-20240115194501-x86_64-linux.hart",
+        }
+      end
+
+      it "takes the package identity from the filename, overriding what was configured" do
+        expect(finalized[:package_origin]).to eq("mycorp")
+        expect(finalized[:package_name]).to eq("wildfly")
+        expect(finalized[:package_version]).to eq("26.1.1")
+        expect(finalized[:package_release]).to eq("20240115194501")
+      end
+    end
+
+    context "when both a service and a supervisor artifact are given" do
+      let(:config) do
+        {
+          kitchen_root: "/kroot",
+          artifact_name: "mycorp-wildfly-26.1.1-20240115194501-x86_64-linux.hart",
+          hab_sup_artifact_name: "core-hab-sup-1.6.652-20240115194501-x86_64-linux.hart",
+        }
+      end
+
+      it "keeps the two identities separate" do
+        expect(finalized[:package_name]).to eq("wildfly")
+        expect(finalized[:hab_sup_name]).to eq("hab-sup")
+        expect(finalized[:hab_sup_version]).to eq("1.6.652")
+      end
+    end
+  end
+
+  describe "#package_ident" do
+    let(:config) { { kitchen_root: "/kroot" } }
+
+    it "emits origin/name when no version or release is set" do
+      config[:package_name] = "redis"
+
+      expect(provisioner.send(:package_ident)).to eq("core/redis")
+    end
+
+    it "emits origin/name/version when only a version is set" do
+      config[:package_name] = "redis"
+      config[:package_version] = "4.0.14"
+
+      expect(provisioner.send(:package_ident)).to eq("core/redis/4.0.14")
+    end
+  end
+
+  describe "#artifact_name_to_package_ident_regex" do
+    let(:config) { { kitchen_root: "/kroot" } }
+
+    it "captures every part of a hart filename" do
+      match = provisioner.send(:artifact_name_to_package_ident_regex)
+        .match("core-redis-4.0.14-20240106065001-x86_64-linux.hart")
+
+      expect(match["origin"]).to eq("core")
+      expect(match["name"]).to eq("redis")
+      expect(match["version"]).to eq("4.0.14")
+      expect(match["release"]).to eq("20240106065001")
+      expect(match["target"]).to eq("x86_64-linux")
+    end
+
+    it "handles a hyphenated package name" do
+      match = provisioner.send(:artifact_name_to_package_ident_regex)
+        .match("core-hab-sup-1.6.652-20240115194501-x86_64-linux.hart")
+
+      expect(match["name"]).to eq("hab-sup")
+      expect(match["version"]).to eq("1.6.652")
+    end
+
+    it "does not match a filename that is not a hart" do
+      expect(provisioner.send(:artifact_name_to_package_ident_regex)
+        .match("core-redis-4.0.14-20240106065001-x86_64-linux.tar.gz")).to be_nil
+    end
+  end
+end

--- a/spec/kitchen/provisioner/habitat/platform_dispatch_spec.rb
+++ b/spec/kitchen/provisioner/habitat/platform_dispatch_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "kitchen/provisioner/habitat"
+
+# Every command this provisioner produces branches on the platform. These
+# examples pin which branch each entry point takes, so a change to
+# windows_os? detection cannot quietly send Windows instances a bash script.
+RSpec.describe Kitchen::Provisioner::Habitat do
+  include_context "habitat provisioner"
+
+  let(:config) { { kitchen_root: "/kroot", root_path: "/tmp/kitchen", package_name: "redis" } }
+
+  shared_examples "a platform-dispatched command" do |method, windows_marker, linux_marker|
+    it "produces the Windows form on Windows" do
+      allow(platform).to receive(:os_type).and_return("windows")
+
+      command = provisioner.public_send(method)
+
+      expect(command).to include(windows_marker)
+      expect(command).not_to include(linux_marker)
+    end
+
+    it "produces the Linux form everywhere else" do
+      allow(platform).to receive(:os_type).and_return("linux")
+
+      command = provisioner.public_send(method)
+
+      expect(command).to include(linux_marker)
+      expect(command).not_to include(windows_marker)
+    end
+  end
+
+  describe "#install_command" do
+    include_examples "a platform-dispatched command",
+      :install_command,
+      "Set-ExecutionPolicy Bypass",
+      "command -v hab"
+
+    it "passes hab_version to the Linux install script when one is pinned" do
+      allow(platform).to receive(:os_type).and_return("linux")
+      config[:hab_version] = "1.6.652"
+
+      expect(provisioner.install_command).to include("bash /tmp/install.sh -v 1.6.652")
+    end
+
+    it "passes no version to the Linux install script when it is 'latest'" do
+      allow(platform).to receive(:os_type).and_return("linux")
+
+      expect(provisioner.install_command).to include("bash /tmp/install.sh\n")
+      expect(provisioner.install_command).not_to include("-v latest")
+    end
+
+    it "passes the channel and version to the Windows install script" do
+      allow(platform).to receive(:os_type).and_return("windows")
+      config[:hab_channel] = "unstable"
+      config[:hab_version] = "1.6.652"
+
+      expect(provisioner.install_command).to include("-ArgumentList unstable, 1.6.652")
+    end
+  end
+
+  describe "#init_command" do
+    include_examples "a platform-dispatched command",
+      :init_command,
+      "core/windows-service",
+      "/etc/systemd/system/hab-sup.service"
+
+    it "creates the config staging directory unless the package config is overridden" do
+      allow(platform).to receive(:os_type).and_return("linux")
+
+      expect(provisioner.init_command).to include("mkdir -p /tmp/kitchen/config")
+    end
+
+    it "leaves the config staging directory to the sandbox upload when overriding" do
+      allow(platform).to receive(:os_type).and_return("linux")
+      config[:override_package_config] = true
+
+      expect(provisioner.init_command).not_to include("mkdir -p /tmp/kitchen/config")
+    end
+  end
+
+  describe "#prepare_command" do
+    it "removes the previous user.toml before installing the new one" do
+      allow(platform).to receive(:os_type).and_return("linux")
+      config[:config_directory] = "configs"
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with("/kroot/configs/user.toml").and_return(true)
+
+      command = provisioner.prepare_command
+
+      expect(command.index("find /hab/user/redis/config -name user.toml -delete"))
+        .to be < command.index("cp /tmp/kitchen/config/user.toml /hab/user/redis/config/user.toml")
+    end
+
+    it "still clears a stale user.toml when no config_directory is configured" do
+      allow(platform).to receive(:os_type).and_return("linux")
+
+      command = provisioner.prepare_command
+
+      expect(command).to include("find /hab/user/redis/config -name user.toml -delete")
+      expect(command).not_to include("cp /tmp/kitchen/config/user.toml")
+    end
+  end
+
+  describe "#run_command" do
+    it "works around the Windows hart landing outside the results directory" do
+      allow(platform).to receive(:os_type).and_return("windows")
+      config[:artifact_name] = "mycorp-wildfly-26.1.1-20240115194501-x86_64-linux.hart"
+
+      expect(provisioner.run_command)
+        .to include("hab pkg install /tmp/kitchen/mycorp-wildfly-26.1.1-20240115194501-x86_64-linux.hart")
+      expect(provisioner.run_command).not_to include("/tmp/kitchen/results/")
+    end
+
+    it "prepends the Habitat directory to PATH on Windows" do
+      allow(platform).to receive(:os_type).and_return("windows")
+
+      expect(provisioner.run_command).to include('$env:Path += ";C:\\ProgramData\\Habitat"')
+    end
+
+    it "waits for the supervisor before installing anything on Linux" do
+      allow(platform).to receive(:os_type).and_return("linux")
+
+      command = provisioner.run_command
+
+      expect(command.index("Waiting 5 seconds for supervisor to finish loading"))
+        .to be < command.index("hab pkg install")
+    end
+  end
+end

--- a/spec/kitchen/provisioner/habitat/sandbox_contents_spec.rb
+++ b/spec/kitchen/provisioner/habitat/sandbox_contents_spec.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require "kitchen/provisioner/habitat"
+require "tmpdir" unless defined?(Dir.mktmpdir)
+
+# These examples use a real temporary directory rather than FakeFS. The
+# sandbox that Kitchen::Provisioner::Base creates lives on the real
+# filesystem, so a faked kitchen_root leaves the copy helpers with nothing to
+# copy and they silently return -- which looks like a passing spec while
+# testing nothing.
+RSpec.describe Kitchen::Provisioner::Habitat do
+  include_context "habitat provisioner"
+
+  let(:kitchen_root) { Dir.mktmpdir("kitchen-habitat-spec") }
+  let(:config) { { kitchen_root: kitchen_root, root_path: "/tmp/kitchen" } }
+
+  after do
+    provisioner.cleanup_sandbox if provisioner.instance_variable_get(:@sandbox_path)
+    FileUtils.remove_entry(kitchen_root) if File.directory?(kitchen_root)
+  end
+
+  def write(relative_path, contents = "")
+    path = File.join(kitchen_root, relative_path)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, contents)
+    path
+  end
+
+  def sandbox_entries
+    Dir.glob(File.join(provisioner.sandbox_path, "**", "*"))
+      .map { |p| p.sub("#{provisioner.sandbox_path}/", "") }
+      .sort
+  end
+
+  describe "#resolve_results_directory" do
+    it "prefers an explicitly configured directory over any it could find" do
+      write("results/keep.txt")
+      config[:results_directory] = "/somewhere/else"
+
+      expect(provisioner.send(:resolve_results_directory)).to eq("/somewhere/else")
+    end
+
+    it "finds results/ beside the kitchen.yml" do
+      write("results/keep.txt")
+
+      expect(provisioner.send(:resolve_results_directory)).to eq(File.join(kitchen_root, "results"))
+    end
+
+    it "falls back to the parent directory, as hab studio lays a plan out" do
+      nested = File.join(kitchen_root, "habitat", "test")
+      FileUtils.mkdir_p(nested)
+      write("habitat/results/keep.txt")
+      config[:kitchen_root] = nested
+
+      expect(provisioner.send(:resolve_results_directory)).to eq(File.join(nested, "../results"))
+    end
+
+    it "falls back to the grandparent directory" do
+      nested = File.join(kitchen_root, "habitat", "test")
+      FileUtils.mkdir_p(nested)
+      write("results/keep.txt")
+      config[:kitchen_root] = nested
+
+      expect(provisioner.send(:resolve_results_directory)).to eq(File.join(nested, "../../results"))
+    end
+
+    it "returns nil when there is no results directory anywhere it looks" do
+      expect(provisioner.send(:resolve_results_directory)).to be_nil
+    end
+  end
+
+  describe "#copy_results_to_sandbox" do
+    let(:artifact) { "mycorp-wildfly-26.1.1-20240115194501-x86_64-linux.hart" }
+
+    it "copies the named artifact into the sandbox" do
+      write("results/#{artifact}", "HART")
+      config[:artifact_name] = artifact
+
+      provisioner.create_sandbox
+
+      expect(sandbox_entries).to include("results", "results/#{artifact}")
+      expect(File.read(File.join(provisioner.sandbox_path, "results", artifact))).to eq("HART")
+    end
+
+    it "copies the newest matching artifact when install_latest_artifact is set" do
+      write("results/mycorp-wildfly-26.1.0-20240101000000-x86_64-linux.hart", "OLD")
+      newest = write("results/mycorp-wildfly-26.1.1-20240115194501-x86_64-linux.hart", "NEW")
+      FileUtils.touch(newest, mtime: Time.now + 60)
+      config[:install_latest_artifact] = true
+      config[:package_origin] = "mycorp"
+      config[:package_name] = "wildfly"
+
+      provisioner.create_sandbox
+
+      expect(sandbox_entries).to include("results/mycorp-wildfly-26.1.1-20240115194501-x86_64-linux.hart")
+      expect(sandbox_entries).not_to include("results/mycorp-wildfly-26.1.0-20240101000000-x86_64-linux.hart")
+    end
+
+    it "copies a custom supervisor artifact alongside the service artifact" do
+      write("results/#{artifact}", "HART")
+      write("results/core-hab-sup-1.6.652-20240115194501-x86_64-linux.hart", "SUP")
+      config[:artifact_name] = artifact
+      config[:hab_sup_artifact_name] = "core-hab-sup-1.6.652-20240115194501-x86_64-linux.hart"
+
+      provisioner.create_sandbox
+
+      expect(sandbox_entries).to include(
+        "results/#{artifact}",
+        "results/core-hab-sup-1.6.652-20240115194501-x86_64-linux.hart"
+      )
+    end
+
+    it "creates no results directory when no artifact was asked for" do
+      write("results/#{artifact}", "HART")
+
+      provisioner.create_sandbox
+
+      expect(sandbox_entries).not_to include("results")
+    end
+  end
+
+  describe "#copy_user_toml_to_sandbox" do
+    it "copies the user.toml out of config_directory" do
+      write("configs/user.toml", "[redis]\nport = 6380\n")
+      config[:config_directory] = "configs"
+
+      provisioner.create_sandbox
+
+      expect(File.read(File.join(provisioner.sandbox_path, "config", "user.toml")))
+        .to eq("[redis]\nport = 6380\n")
+    end
+
+    it "renames the file named by user_toml_name to user.toml in the sandbox" do
+      write("configs/user-ha.toml", "ha = true\n")
+      config[:config_directory] = "configs"
+      config[:user_toml_name] = "user-ha.toml"
+
+      provisioner.create_sandbox
+
+      expect(sandbox_entries).to include("config/user.toml")
+      expect(sandbox_entries).not_to include("config/user-ha.toml")
+    end
+
+    it "does nothing when config_directory holds no such file" do
+      write("configs/default.toml", "")
+      config[:config_directory] = "configs"
+
+      provisioner.create_sandbox
+
+      expect(sandbox_entries).not_to include("config/user.toml")
+    end
+
+    it "does nothing when no config_directory is set" do
+      provisioner.create_sandbox
+
+      expect(sandbox_entries).to be_empty
+    end
+  end
+
+  describe "#copy_package_config_from_override_to_sandbox" do
+    before do
+      write("configs/user.toml", "port = 6380\n")
+      write("configs/default.toml", "port = 6379\n")
+      write("configs/hooks/run", "#!/bin/sh\n")
+    end
+
+    it "copies the whole config directory when override_package_config is set" do
+      config[:config_directory] = "configs"
+      config[:override_package_config] = true
+
+      provisioner.create_sandbox
+
+      expect(sandbox_entries).to include("config/default.toml", "config/hooks/run", "config/user.toml")
+    end
+
+    it "copies only the user.toml when override_package_config is not set" do
+      config[:config_directory] = "configs"
+
+      provisioner.create_sandbox
+
+      expect(sandbox_entries).to contain_exactly("config", "config/user.toml")
+    end
+
+    it "does nothing when the configured directory does not exist" do
+      config[:config_directory] = "nope"
+      config[:override_package_config] = true
+
+      provisioner.create_sandbox
+
+      expect(sandbox_entries).to be_empty
+    end
+  end
+
+  describe "#get_artifact_name" do
+    it "resolves the newest artifact and back-fills the package identity" do
+      write("results/mycorp-wildfly-26.1.0-20240101000000-x86_64-linux.hart", "OLD")
+      newest = write("results/mycorp-wildfly-26.1.1-20240115194501-x86_64-linux.hart", "NEW")
+      FileUtils.touch(newest, mtime: Time.now + 60)
+      config[:install_latest_artifact] = true
+      config[:package_origin] = "mycorp"
+      config[:package_name] = "wildfly"
+
+      path = provisioner.send(:get_artifact_name)
+
+      expect(path).to eq("/tmp/kitchen/results/mycorp-wildfly-26.1.1-20240115194501-x86_64-linux.hart")
+      expect(provisioner.send(:config)[:package_version]).to eq("26.1.1")
+      expect(provisioner.send(:config)[:package_release]).to eq("20240115194501")
+    end
+
+    it "returns nil when no local artifact was asked for" do
+      expect(provisioner.send(:get_artifact_name)).to be_nil
+    end
+  end
+end

--- a/spec/kitchen/provisioner/habitat/sandbox_spec.rb
+++ b/spec/kitchen/provisioner/habitat/sandbox_spec.rb
@@ -28,42 +28,6 @@ RSpec.describe Kitchen::Provisioner::Habitat do
     end
   end
 
-  describe "#copy_package_config_from_override_to_sandbox" do
-    it "should create a config folder in the sandbox" do
-      provisioner.create_sandbox
-      config[:config_directory] = "config"
-      config[:override_package_config] = true
-      FakeFS.activate!
-      FileUtils.mkdir_p("#{provisioner.sandbox_path}/config")
-
-      provisioner.send(
-        :copy_package_config_from_override_to_sandbox
-      )
-      expect(File).to exist("#{provisioner.sandbox_path}/config")
-      FakeFS.deactivate!
-      FakeFS::FileSystem.clear
-      provisioner.cleanup_sandbox
-    end
-  end
-
-  describe "#copy_results_to_sandbox" do
-    it "should create a results folder in the sandbox" do
-      provisioner.create_sandbox
-      config[:artifact_name] = "example-package-0.1.0-20200406205105-x86_64-linux.hart"
-      FakeFS.activate!
-      FileUtils.mkdir_p("#{provisioner.sandbox_path}/results")
-      FileUtils.touch("#{provisioner.sandbox_path}/results/#{config[:artifact_name]}")
-
-      provisioner.send(
-        :copy_results_to_sandbox
-      )
-      expect(File).to exist("#{provisioner.sandbox_path}/results/#{config[:artifact_name]}")
-      FakeFS.deactivate!
-      FakeFS::FileSystem.clear
-      provisioner.cleanup_sandbox
-    end
-  end
-
   describe "#full_user_toml_path" do
     describe "for windows operating systems" do
       before { allow(platform).to receive(:os_type).and_return("windows") }


### PR DESCRIPTION
The spec suite was 976 lines against 711 lines of `lib/`, which looks healthy until you see what it covers: almost all of it is `supervisor_options` and `service_options`, one `expect(...).to include("--flag value")` per option. None of the four methods a converge actually calls — `install_command`, `init_command`, `prepare_command`, `run_command` — had a single example, and neither did the package identity normalisation or anything the sandbox does.

### What this adds

**`finalize_config!`** — the only place package identity is normalised, and everything downstream assumes it has already run. Covered: a bare `package_name`, an `origin/name` pair, a fully qualified `core/redis/4.0.14/20240106065001`, a nil name, an `artifact_name` overriding what was configured, and a service and supervisor artifact given together without bleeding into each other.

**The hart filename regex** — a hyphenated package name (`core-hab-sup-1.6.652-...`, where the name has to win the hyphens over the version), and a filename that should not match at all.

**Platform dispatch** — `install_command`, `init_command`, `prepare_command` and `run_command` each get a shared example pinning which branch they take, plus the ordering the generated scripts actually depend on (the supervisor wait before `hab pkg install`, the `user.toml` removal before the copy) and the Windows hart-path workaround.

**`resolve_results_directory`** — the `../results` and `../../results` fallbacks that cover the usual `hab studio` layouts had no coverage at all.

**Everything `create_sandbox` stages** — the named artifact, the newest artifact under `install_latest_artifact`, a custom supervisor artifact alongside the service one, the `user_toml_name` rename to `user.toml`, and the `override_package_config` directory copy versus the `user.toml`-only default.

### Two existing examples were replaced, not added to

`#copy_results_to_sandbox` and `#copy_package_config_from_override_to_sandbox` looked like this:

```ruby
provisioner.create_sandbox
config[:artifact_name] = "example-package-...hart"
FakeFS.activate!
FileUtils.mkdir_p("#{provisioner.sandbox_path}/results")
FileUtils.touch("#{provisioner.sandbox_path}/results/#{config[:artifact_name]}")

provisioner.send(:copy_results_to_sandbox)
expect(File).to exist("#{provisioner.sandbox_path}/results/#{config[:artifact_name]}")
```

The assertion passes on the file the example created itself. Meanwhile the code under test looked into a freshly faked, empty filesystem, found no results directory, and returned on the second line — the copy was never reached. SimpleCov confirms it: `FileUtils.cp` and `FileUtils.copy_entry` were both unexecuted before this branch.

The replacements use a real temporary `kitchen_root`, which is what the sandbox lives on anyway, so mixing FakeFS in was always going to leave one half of the copy pointing at a different filesystem than the other.

### Numbers

```
$ bundle exec cookstyle --chefstyle
5 files inspected, no offenses detected

$ bundle exec rake test
128 examples, 0 failures
Line Coverage: 99.55% (219 / 220)
Branch Coverage: 90.98% (111 / 122)
```

Before this branch: 86 examples, 81.82% line, 68.85% branch. The percentage is not the point — the branches are. Artifact selection, platform dispatch, and sandbox staging are where a bug in this provisioner can actually hide, and none of them were being looked at.