### PR TITLE
ci: converge for real against Habitat in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 ---
-name: "Test"
+name: 'Lint, Unit & Integration Tests'
 
 "on":
   pull_request:
@@ -7,3 +7,26 @@ name: "Test"
 jobs:
   lint-unit:
     uses: test-kitchen/.github/.github/workflows/lint-unit.yml@main
+
+  integration-linux:
+    name: Linux ${{ matrix.suite }}
+    runs-on: ubuntu-latest
+    needs: lint-unit
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - default
+          - user-toml
+          - library-package
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - run: bundle exec kitchen test ${{ matrix.suite }}-ubuntu-2404
+      - name: Supervisor log on failure
+        if: failure()
+        run: sudo journalctl -u hab-sup --no-pager || true

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ tmp
 _yardoc
 doc/
 .rspec_status
+
+# Test Kitchen
+.kitchen/
+.kitchen.local.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,22 +54,45 @@ bundle exec cookstyle -a
 ```
 
 The unit tests exercise the provisioner's generated shell and PowerShell
-directly and use [fakefs](https://github.com/fakefs/fakefs) for the file
-copying, so they neither build machines nor need the `hab` CLI installed.
+directly, so they neither build machines nor need the `hab` CLI installed.
 
-### Manual testing against a real machine
+### Integration tests
 
 The unit tests assert on the *text* of the commands the provisioner generates.
-They cannot tell you whether those commands actually work, so changes to the
-install, supervisor, or service-load logic should also be exercised for real:
+They cannot tell you whether those commands actually run, so there are Test
+Kitchen suites in `kitchen.yml` that converge for real:
+
+| Suite | What it covers |
+| --- | --- |
+| `default` | Install the CLI, start a supervisor, install `core/redis` from Builder, load it, and wait for it in `hab svc status`. |
+| `user-toml` | A `user.toml` staged from `config_directory` under a non-default `user_toml_name`, installed into `/hab/user` by `prepare_command`, plus a non-default supervisor HTTP gateway. |
+| `library-package` | `core/jq-static`, which has no `run` hook. `run_command` must install it and then leave it alone rather than waiting out `service_load_timeout`. |
+
+The assertions live in `test/integration/verify.sh` and are selected by
+`KITCHEN_SUITE`.
+
+These suites use the `exec` driver, which runs every command on the machine
+Test Kitchen is already running on. That is what makes them a real test — a
+real `hab` CLI, a real systemd unit, a real supervisor — and it also means
+**there is no isolation**. They install packages, add a `hab` user and group,
+write to `/etc/systemd/system`, and start a service. Run them on a disposable
+machine only:
 
 ```sh
-bundle exec kitchen test
+bundle exec kitchen test default-ubuntu-2404
 ```
 
-Test both a Linux and a Windows platform when you touch anything in
-`install_command`, `init_command`, or `run_command` — the two paths share
-almost no code, and it is easy to fix one while breaking the other.
+CI runs all three on a fresh Ubuntu runner per suite, so pushing a branch is
+the easiest way to exercise them.
+
+### Windows
+
+There is no automated coverage of the Windows path yet — it installs
+`core/windows-service` and edits `HabService.dll.config`, which the `exec`
+driver cannot do safely on a shared runner. Test it by hand against a Windows
+VM when you touch anything in `install_command`, `init_command`, or
+`run_command`: the two platform paths share almost no code, and it is easy to
+fix one while breaking the other.
 
 ## Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,13 @@ Kitchen suites in `kitchen.yml` that converge for real:
 The assertions live in `test/integration/verify.sh` and are selected by
 `KITCHEN_SUITE`.
 
+The suites pin `hab_version` to `1.6.1245`. Habitat 2.x moved the `hab` CLI and
+the supervisor into the `chef` origin on Builder, which requires a Personal
+Access Token, so an unpinned `install.sh` now fails with `401 Unauthorized`
+before `hab` reaches the PATH. `1.6.1245` is the last release whose manifest
+points at the still-public `core` origin. Unpin it once the provisioner can
+pass a `HAB_AUTH_TOKEN` through and CI has one to pass.
+
 These suites use the `exec` driver, which runs every command on the machine
 Test Kitchen is already running on. That is what makes them a real test — a
 real `hab` CLI, a real systemd unit, a real supervisor — and it also means

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,0 +1,53 @@
+---
+# Integration suites for the provisioner itself.
+#
+# The `exec` driver runs every command on the machine Test Kitchen is already
+# running on, and forces the matching `exec` transport, so a converge here
+# installs the real `hab` CLI, writes a real systemd unit, starts a real
+# supervisor, and loads a real service from Builder. That is the only way to
+# find out whether the shell this provisioner generates actually runs -- the
+# unit tests can only tell you what it says.
+#
+# There is no isolation. Run these on a disposable machine (a CI runner, a
+# throwaway VM, a container), never on your workstation. See CONTRIBUTING.md.
+driver:
+  name: exec
+
+provisioner:
+  name: habitat
+  hab_license: accept
+  depot_url: https://bldr.habitat.sh
+
+verifier:
+  name: shell
+  command: bash test/integration/verify.sh
+
+platforms:
+  - name: ubuntu-2404
+
+suites:
+  # The ordinary case: install the CLI, start a supervisor, pull a package
+  # from Builder, load it, and wait for it to appear in `hab svc status`.
+  - name: default
+    provisioner:
+      package_origin: core
+      package_name: redis
+
+  # A user.toml is staged into the sandbox, uploaded, and installed into
+  # /hab/user by prepare_command, and the supervisor is given a non-default
+  # HTTP gateway address.
+  - name: user-toml
+    provisioner:
+      package_origin: core
+      package_name: redis
+      config_directory: test/fixtures/redis-config
+      user_toml_name: redis-user.toml
+      hab_sup_listen_http: 0.0.0.0:9631
+
+  # A package with no run hook. run_command must install it and then leave it
+  # alone rather than loading it and waiting out service_load_timeout.
+  - name: library-package
+    provisioner:
+      package_origin: core
+      package_name: jq-static
+      service_load_timeout: 60

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,6 +17,20 @@ provisioner:
   name: habitat
   hab_license: accept
   depot_url: https://bldr.habitat.sh
+  # Pinned deliberately, and not just to keep the suites reproducible.
+  #
+  # Habitat 2.x moved the `hab` CLI and the supervisor into the `chef` origin
+  # on Builder, and that origin needs a Personal Access Token. `install.sh`
+  # with no `-v` reads the origin out of the latest manifest, gets `chef`, and
+  # dies with `[401 Unauthorized] Please check that you have specified a valid
+  # Personal Access Token` before `hab` is ever on the PATH.
+  #
+  # 1.6.1245 is the last release whose manifest points at `core`, which is
+  # still public, so `core/hab`, `core/hab-sup`, `core/hab-launcher` and the
+  # `core` packages the suites load all download unauthenticated. This also
+  # means the suites exercise the `hab_version` option rather than defaulting
+  # past it.
+  hab_version: "1.6.1245"
 
 verifier:
   name: shell

--- a/test/fixtures/redis-config/redis-user.toml
+++ b/test/fixtures/redis-config/redis-user.toml
@@ -1,0 +1,6 @@
+# Staged into the sandbox as config/user.toml and installed to
+# /hab/user/redis/config/user.toml by the provisioner's prepare_command.
+# The filename deliberately is not user.toml so that user_toml_name is
+# exercised too.
+port = 6380
+protected-mode = "no"

--- a/test/integration/verify.sh
+++ b/test/integration/verify.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Asserts that the converge did what the provisioner claims it does.
+#
+# Run by the `shell` verifier, which executes locally -- which is the instance
+# itself, because these suites use the `exec` driver. KITCHEN_SUITE is exported
+# by the verifier.
+set -euo pipefail
+
+export PATH="/bin:/usr/bin:${PATH}"
+
+fail() {
+  echo "FAIL: $*" >&2
+  echo "--- hab svc status ---" >&2
+  sudo -E hab svc status >&2 || true
+  echo "--- hab-sup journal (last 50 lines) ---" >&2
+  sudo journalctl -u hab-sup -n 50 --no-pager >&2 || true
+  exit 1
+}
+
+pass() { echo "ok: $*"; }
+
+# --- Assertions that hold for every suite ------------------------------------
+
+command -v hab >/dev/null 2>&1 || fail "the hab CLI is not on PATH"
+pass "hab CLI installed: $(hab --version)"
+
+[ -f /etc/systemd/system/hab-sup.service ] || fail "no hab-sup systemd unit was written"
+pass "hab-sup systemd unit written"
+
+systemctl is-active --quiet hab-sup || fail "the hab-sup service is not running"
+pass "hab-sup service is running"
+
+grep -q 'HAB_LICENSE=accept' /etc/systemd/system/hab-sup.service ||
+  fail "hab_license was not passed to the supervisor"
+pass "HAB_LICENSE passed to the supervisor"
+
+getent group hab >/dev/null 2>&1 || fail "the hab group was not created"
+id -u hab >/dev/null 2>&1 || fail "the hab user was not created"
+pass "hab user and group exist"
+
+sudo -E hab svc status >/dev/null 2>&1 || fail "the supervisor is not answering hab svc status"
+pass "supervisor answers hab svc status"
+
+# --- Per-suite assertions ----------------------------------------------------
+
+case "${KITCHEN_SUITE}" in
+default)
+  sudo -E hab svc status | grep -q 'core/redis' || fail "core/redis was not loaded"
+  pass "core/redis is loaded"
+  ;;
+
+user-toml)
+  sudo -E hab svc status | grep -q 'core/redis' || fail "core/redis was not loaded"
+  pass "core/redis is loaded"
+
+  [ -f /hab/user/redis/config/user.toml ] ||
+    fail "user.toml was not installed into /hab/user/redis/config"
+  sudo grep -q 'port = 6380' /hab/user/redis/config/user.toml ||
+    fail "/hab/user/redis/config/user.toml does not hold our settings"
+  pass "user.toml installed from user_toml_name"
+
+  grep -q -- '--listen-http 0.0.0.0:9631' /etc/systemd/system/hab-sup.service ||
+    fail "hab_sup_listen_http was not passed to the supervisor"
+  pass "supervisor started with the configured HTTP gateway"
+  ;;
+
+library-package)
+  sudo -E hab pkg path core/jq-static >/dev/null 2>&1 ||
+    fail "core/jq-static was not installed"
+  pass "core/jq-static is installed"
+
+  if sudo -E hab svc status 2>/dev/null | grep -q 'jq-static'; then
+    fail "a package with no run hook was loaded as a service"
+  fi
+  pass "a package with no run hook was left unloaded"
+  ;;
+
+*)
+  fail "no assertions defined for suite ${KITCHEN_SUITE}"
+  ;;
+esac
+
+echo "All assertions passed for suite ${KITCHEN_SUITE}."


### PR DESCRIPTION
There is no `kitchen.yml` in this repository, so nothing has ever converged. Everything we test asserts on the *text* of the shell and PowerShell the provisioner generates, which means a script can match its expectation word for word and still not run — which is exactly what was happening in #97.

This adds three Test Kitchen suites and a matrix job that runs each on its own fresh Ubuntu runner.

### The suites

| Suite | What it proves |
| --- | --- |
| `default` | The CLI installs, the systemd unit is written, a supervisor starts, `core/redis` comes down from Builder, gets loaded, and shows up in `hab svc status`. |
| `user-toml` | A `user.toml` staged from `config_directory` under a non-default `user_toml_name` reaches `/hab/user/redis/config/user.toml`, and `hab_sup_listen_http` reaches the supervisor. |
| `library-package` | `core/jq-static` has no `run` hook, so `run_command` must install it and leave it alone rather than loading it and sitting in the wait loop until `service_load_timeout`. |

### Why the `exec` driver

`driver: exec` ships with Test Kitchen and runs every command on the machine Test Kitchen is already running on, forcing the matching `exec` transport. A GitHub runner is exactly the disposable machine that wants.

The alternative was a container, and a container is the wrong shape for this provisioner: `init_command` writes a `hab-sup` systemd unit and runs `systemctl start`, so a plain Docker image would have to be a systemd-in-a-container special case before it proved anything. On the runner, systemd is simply there, so what CI exercises is the same code path a user gets on a real VM.

The cost is that there is no isolation — the suites install packages, add a `hab` user and group, write to `/etc/systemd/system`, and start a service. `CONTRIBUTING.md` now says that plainly, along with which suite covers what.

One suite per job, so each starts from a clean machine and none of them can be passing because a previous suite already installed the supervisor.

### Assertions

`test/integration/verify.sh`, run by the `shell` verifier and selected by `KITCHEN_SUITE`. Every suite checks what should be true for all of them — `hab` on PATH, the unit file written, `hab-sup` active, `HAB_LICENSE` passed through, the `hab` user and group created, the supervisor answering `hab svc status` — before its own assertions. On failure it dumps `hab svc status` and the `hab-sup` journal, and the job does too.

### Windows

Left out on purpose. That path installs `core/windows-service` and rewrites `HabService.dll.config`, which the `exec` driver cannot do safely on a shared runner. `CONTRIBUTING.md` now says it needs manual testing against a VM — previously it just told people to run `bundle exec kitchen test` against a `kitchen.yml` that did not exist.

### Verification

```
$ bundle exec cookstyle --chefstyle
5 files inspected, no offenses detected

$ bundle exec rake test
86 examples, 0 failures

$ bundle exec kitchen list
Instance                     Driver  Provisioner  Verifier  Transport  Last Action    Last Error
default-ubuntu-2404          Exec    Habitat      Shell     Exec       <Not Created>  <None>
user-toml-ubuntu-2404        Exec    Habitat      Shell     Exec       <Not Created>  <None>
library-package-ubuntu-2404  Exec    Habitat      Shell     Exec       <Not Created>  <None>

$ yamllint -c .yamllint kitchen.yml .github/workflows/lint.yml   # clean
$ bash -n test/integration/verify.sh                             # clean
```

The suites themselves need Linux and systemd, so the real verification is this PR's own CI run.