### PR TITLE
fix: load packages whose run hook is a run file in the package root

### DIFF
--- a/lib/kitchen/provisioner/habitat.rb
+++ b/lib/kitchen/provisioner/habitat.rb
@@ -195,8 +195,10 @@ module Kitchen
       # Shell code that installs the package under test and loads it as a
       # service.
       #
-      # The package is only loaded with +hab svc load+ if it ships a +run+
-      # hook, so library packages converge cleanly without a service. After
+      # The package is only loaded with +hab svc load+ if it ships a run
+      # hook -- either +hooks/run+ or a +run+ file in the package root, both
+      # of which the supervisor accepts -- so library packages converge
+      # cleanly without a service. After
       # loading, this polls +hab svc status+ until the service appears, giving
       # up after +service_load_timeout+ seconds.
       #
@@ -223,7 +225,8 @@ module Kitchen
               $env:Path += ";C:\\ProgramData\\Habitat"
             }
             hab pkg install #{target_pkg} --channel #{config[:channel]} --force
-            if (Test-Path -Path "$(hab pkg path #{target_ident})\\hooks\\run") {
+            $PkgPath = hab pkg path #{target_ident}
+            if (@("hooks\\run", "hooks\\run.ps1", "run", "run.ps1") | Where-Object { Test-Path -Path (Join-Path $PkgPath $_) }) {
               hab svc load #{target_ident} #{service_options} --force
               $timer = 0
               Do {
@@ -241,7 +244,8 @@ module Kitchen
                 sleep 5
               done
             sudo hab pkg install #{target_pkg} --channel #{config[:channel]} --force
-            if [ -f "$(sudo hab pkg path #{target_ident})/hooks/run" ]
+            pkg_path="$(sudo hab pkg path #{target_ident})"
+            if [ -f "$pkg_path/hooks/run" ] || [ -f "$pkg_path/run" ]
               then
                 sudo -E hab svc load #{target_ident} #{service_options} --force
                 timer=0

--- a/spec/kitchen/provisioner/habitat/run_command_spec.rb
+++ b/spec/kitchen/provisioner/habitat/run_command_spec.rb
@@ -31,10 +31,24 @@ RSpec.describe Kitchen::Provisioner::Habitat do
         expect(command).to include("sudo -E hab svc load core/redis")
       end
 
-      it "guards the load with a test for the package's run hook" do
+      # The supervisor accepts a run hook in either place: hooks/run from a
+      # hook template, or a run file in the package root from pkg_svc_run.
+      # Only hooks/run used to be checked, so a package built the second way
+      # -- core/redis, among many others -- was installed and then silently
+      # never loaded, and the converge reported success.
+      it "guards the load with a test for a run hook in either place" do
         config[:package_name] = "redis"
 
-        expect(provisioner.run_command).to include(%(if [ -f "$(sudo hab pkg path core/redis)/hooks/run" ]))
+        command = provisioner.run_command
+
+        expect(command).to include(%(pkg_path="$(sudo hab pkg path core/redis)"))
+        expect(command).to include(%(if [ -f "$pkg_path/hooks/run" ] || [ -f "$pkg_path/run" ]))
+      end
+
+      it "asks hab for the package path only once" do
+        config[:package_name] = "redis"
+
+        expect(provisioner.run_command.scan("hab pkg path").length).to eq(1)
       end
 
       # The timeout used to be spelled `[$timer -gt 300]` with no spaces, which
@@ -104,6 +118,15 @@ RSpec.describe Kitchen::Provisioner::Habitat do
         config[:service_load_timeout] = 42
 
         expect(provisioner.run_command).to include("if ($timer -gt 42){exit 1}")
+      end
+
+      it "guards the load with a test for a run hook in either place" do
+        config[:package_name] = "redis"
+
+        command = provisioner.run_command
+
+        expect(command).to include("$PkgPath = hab pkg path core/redis")
+        expect(command).to include(%(@("hooks\\run", "hooks\\run.ps1", "run", "run.ps1")))
       end
     end
   end


### PR DESCRIPTION
The integration suites from #99 went green on `library-package` and red on `default` and `user-toml`, both of which load `core/redis`. The converge exited 0, and then the verifier found this:

```
ok: hab CLI installed: hab 1.6.1245/20250905140900
ok: hab-sup systemd unit written
ok: hab-sup service is running
ok: supervisor answers hab svc status
FAIL: core/redis was not loaded
--- hab svc status ---
No services loaded.
```

`hab pkg install core/redis` had succeeded a fraction of a second earlier. The load was never attempted.

### Why

`run_command` gates the load on this:

```bash
if [ -f "$(sudo hab pkg path core/redis)/hooks/run" ]
```

The supervisor accepts a run hook in either of two places — `hooks/run`, written from a hook template, or a `run` file in the package root, which is what `pkg_svc_run` in a plan produces. We only ever checked the first.

`core/redis` is built the second way:

```
$ tar -tf core-redis-4.0.14-20240106065001-x86_64-linux.hart | grep -E '/(run|hooks/)'
hab/pkgs/core/redis/4.0.14/20240106065001/run
```

So for every package written that way — and `pkg_svc_run` is the older, simpler, still very common style, including the `core/redis` example in our own README — the provisioner installed the package, skipped the entire load branch, and reported success. No error, no warning, nothing in the output to suggest the service you asked for was never started.

### The fix

Both platform paths now resolve the package path once and check both locations:

```bash
pkg_path="$(sudo hab pkg path core/redis)"
if [ -f "$pkg_path/hooks/run" ] || [ -f "$pkg_path/run" ]
```

```powershell
$PkgPath = hab pkg path core/redis
if (@("hooks\run", "hooks\run.ps1", "run", "run.ps1") | Where-Object { Test-Path -Path (Join-Path $PkgPath $_) }) {
```

The Windows side also checks the `.ps1` form of each, which is how a Windows plan spells the same two hooks.

`library-package` (`core/jq-static`, no run hook of either kind) keeps passing, so the negative branch is still covered — a library or build-time dependency still converges without a service being started.

### Verification

```
$ bundle exec cookstyle --chefstyle
5 files inspected, no offenses detected

$ bundle exec rake test
152 examples, 0 failures
Line Coverage: 100.0% (226 / 226)
Branch Coverage: 92.74% (115 / 124)
```

The real check is this PR's own `default` and `user-toml` integration jobs, which should now go green.