### PR TITLE
chore: remove SimpleCov code-coverage tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ Gemfile.lock
 *.gem
 .bundle
 .config
-coverage
 InstalledFiles
 lib/bundler/man
 pkg

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ group :test do
   gem "fakefs"
   gem "rake", ">= 11.0"
   gem "rspec", "~> 3.2"
-  gem "simplecov", "~> 0.22"
 end
 
 group :docs do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,14 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "simplecov"
-
-SimpleCov.start do
-  add_filter "/spec/"
-  add_group "Provisioner", "lib/kitchen/provisioner"
-  enable_coverage :branch
-end
-
 require "rspec"
 require "kitchen"
 


### PR DESCRIPTION
## What

Removes SimpleCov and everything that existed only to serve it:

- `gem "simplecov", "~> 0.22"` from the `:test` group in `Gemfile`
- `require "simplecov"` and the `SimpleCov.start` block (`add_filter`, `add_group`, `enable_coverage :branch`) from `spec/spec_helper.rb`
- the `coverage` artifact path from `.gitignore`

That is the whole footprint. There was no `minimum_coverage` enforcement, no `COVERAGE` env-var branching, no coverage rake task, and no CI step that uploaded or reported coverage, so there was nothing else to take out.

## What this does not touch

**The YARD `doc` and `doc_coverage` rake tasks stay.** `doc_coverage` runs `yard stats --list-undoc` — that is *documentation* coverage, not code coverage, and it is the thing that keeps `lib/` at 100% documented. Both still work:

```
$ bundle exec rake -T
rake doc                    # Generate YARD Documentation
rake doc_coverage           # List anything in lib/ that is still undocumented

$ bundle exec rake doc_coverage
yard stats --list-undoc
Modules:         3 (    0 undocumented)
Classes:         1 (    0 undocumented)
Constants:       3 (    0 undocumented)
Attributes:      0 (    0 undocumented)
Methods:        30 (    0 undocumented)
 100.00% documented
```

Also untouched: the sentence in `CONTRIBUTING.md` about there being "no automated coverage of the Windows path yet". That is a statement about which platforms the suite exercises, not about the measurement tool, and it is still true.

## Why

Nothing gated on the numbers. No CI job published a report, no threshold failed a build, and the only consumer was whoever opened `coverage/index.html` locally. What it did cost was a development dependency and a Renovate stream for a gem that measures the suite rather than testing it.

The recent test work stands on its own: this removes the measurement, not a single test.

## Verification

Example count is unchanged — this was verified against `origin/main` before the change and again after:

```
before:  152 examples, 0 failures   (Line 100.0% (226/226), Branch 92.74% (115/124))
after:   152 examples, 0 failures
```

Lint, with **Cookstyle 9.0.0 / RuboCop 1.90.0** (bundle updated first so it matches what CI resolves, since `Gemfile.lock` is gitignored):

```
$ bundle exec cookstyle --chefstyle
Inspecting 5 files
.....

5 files inspected, no offenses detected
```

Greps, run from the repo root excluding `.git`, both return nothing:

```
$ grep -rin 'simplecov' . --exclude-dir=.git   # no matches
$ grep -rn 'COVERAGE' . --exclude-dir=.git     # no matches
```

## Notes

- **No CHANGELOG entry mentions simplecov** — I checked (`grep -in 'simplecov\|coverage' CHANGELOG.md` is empty). SimpleCov was added after the 0.13.1 release, so it never reached published release history. Nothing was edited in that release-please-managed file.
- **#96** (`renovate/simplecov-1.x`) is made obsolete by this change and should be closed once this lands. It has in fact already been closed independently, so no action is likely needed — but if Renovate reopens it, close it rather than trying to fix it. It was red because simplecov 1.x requires Ruby > 3.1 and this gemspec supports 3.1.
- **#103** (`fix:` the `hab svc load` run-hook detection) has already merged into `main`; this branch is cut from the resulting `aac0970`. It touched only `lib/kitchen/provisioner/habitat.rb` and `spec/kitchen/provisioner/habitat/run_command_spec.rb` — not `spec/spec_helper.rb`, the `Gemfile`, or the `Rakefile` — so there is no overlap and no merge-order constraint between the two.
